### PR TITLE
resolves #6 Require dict.json from process.cwd() or opts.path not __dirname

### DIFF
--- a/i18n/i18ify.js
+++ b/i18n/i18ify.js
@@ -1,19 +1,21 @@
 /*
 # i18ify - used at build time to replace text in templates.
 */
+var fs = require('fs')
 var path = require('path')
 var through = require('through2')
 var trumpet = require('trumpet')
 var trim = require('underscore.string').trim
 var i18n = require('./i18n.js')
 
-var baseDir = process.cwd()
-
 module.exports = function (file, opts) {
   if (!isHandlebars(file)) return through()
 
-  console.log('i18nfy', opts.lang)
-  var dict = require(['.', opts.lang, 'dict.json'].join('/'))
+  opts = opts || {}
+
+  var baseDir = process.cwd()
+  var dictPath = path.join(opts.path || baseDir, opts.lang, 'dict.json')
+  var dict = JSON.parse(fs.readFileSync(dictPath))
   var key = path.relative(baseDir, file)
   var tr = trumpet()
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "i18n",
+  "name": "i18n-browserify",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -8,8 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "watchify app.js -o dist/en/bundle.js -t [ pkgify --packages [ --i18n i18n/en/en.js ] ] -t hbsfy",
     "bundle": "mkdir -p dist/en; browserify app.js -o dist/en/bundle.js -t [ pkgify --packages [ --i18n ./i18n/en/en.js ] ] -t hbsfy",
-    "bundle_es": "mkdir -p dist/es; browserify app.js -o dist/es/bundle.js -t [ pkgify --packages [ --i18n i18n/es/es.js ] ] -t [ ./i18n/i18ify.js --lang es ] -t hbsfy",
-    "bundle_de": "mkdir -p dist/de; browserify app.js -o dist/de/bundle.js -t [ pkgify --packages [ --i18n i18n/de/de.js ] ] -t [ ./i18n/i18ify.js --lang de ] -t hbsfy",
+    "bundle_es": "mkdir -p dist/es; browserify app.js -o dist/es/bundle.js -t [ pkgify --packages [ --i18n i18n/es/es.js ] ] -t [ ./i18n/i18ify.js --path i18n --lang es ] -t hbsfy",
+    "bundle_de": "mkdir -p dist/de; browserify app.js -o dist/de/bundle.js -t [ pkgify --packages [ --i18n i18n/de/de.js ] ] -t [ ./i18n/i18ify.js --path i18n --lang de ] -t hbsfy",
     "bundle_all": "npm run bundle & npm run bundle_de & npm run bundle_es; npm run html",
     "html": "find dist -type d -depth 1 -exec cp index.html {} \\;"
   },


### PR DESCRIPTION
Switched to `fs.readFileSync` instead of require so that the path is taken from `cwd` if relative.

New `path` option allows you to specify the path to the directory with localizations.
