### PR TITLE
Translate attrs

### DIFF
--- a/dist/de/bundle.js
+++ b/dist/de/bundle.js
@@ -8,7 +8,7 @@ Handlebars.registerHelper('ngettext', function (one, other, count) {
 
 require('./login')
 
-},{"./i18n/de/de.js":2,"./login":6,"handlebars/runtime":13}],2:[function(require,module,exports){
+},{"./i18n/de/de.js":2,"./login":6,"handlebars/runtime":14}],2:[function(require,module,exports){
 // Configure moment.js
 var moment = require('moment')
 require('moment/locale/de')
@@ -19,7 +19,7 @@ var i18n = require('../i18n.js')
 module.exports = i18n(require('./dict.json'))
 module.exports.moment = moment
 module.exports.locale = 'de'
-},{"../i18n.js":4,"./dict.json":3,"moment":17,"moment/locale/de":16}],3:[function(require,module,exports){
+},{"../i18n.js":4,"./dict.json":3,"moment":18,"moment/locale/de":17}],3:[function(require,module,exports){
 module.exports={
   "frontend": {
     "" : {
@@ -36,7 +36,8 @@ module.exports={
     "There is 1 new alert": ["Es gibt ein neues alarm", "Es gibt 3 neue Alarm"],
     "There is 1 new warning": ["Es gibt ein neues warnung", "Es gibt 3 neue warnungen"],
     "There will be 1h of scheduled maintenance on %s": ["Es wird am %s 1 Uhr von wartungsarbeiten werden"],
-    "Please enter your email and password to log in": ["Bitte geben Sie Ihre E-Mail und Passwort für die Anmeldung in"]
+    "Please enter your email and password to log in": ["Bitte geben Sie Ihre E-Mail und Passwort für die Anmeldung in"],
+    "Your email address": ["Ihre E-Mail-Adresse"]
   }
 }
 
@@ -54,7 +55,7 @@ module.exports = function (dict) {
   })
 }
 
-},{"jed":15}],5:[function(require,module,exports){
+},{"jed":16}],5:[function(require,module,exports){
 // hbsfy compiled Handlebars template
 var HandlebarsCompiler = require('hbsfy/runtime');
 module.exports = HandlebarsCompiler.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
@@ -76,12 +77,12 @@ module.exports = HandlebarsCompiler.template({"compiler":[6,">= 2.0.0-beta.1"],"
     + alias3(((helper = (helper = helpers.locale || (depth0 != null ? depth0.locale : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"locale","hash":{},"data":data}) : helper)))
     + "\"></div>\n    </div>\n\n    <div class=\"col-sm-6\">\n      <form class=\"login__form form\">\n        <h3 data-i18n=\"login/index.hbs\">Login</h3>\n        <p class=\"login__lead\" data-i18n=\"login/index.hbs\">Bitte geben Sie Ihre E-Mail und Passwort für die Anmeldung in</p>\n        <div class=\"form-group\">\n            <label for=\"username\" data-i18n=\"login/index.hbs\">Email</label>\n            <input type=\"text\" class=\"form-control\" name=\"username\" autocorrect=\"off\" autocapitalize=\"off\" value=\""
     + ((stack1 = this.lambda(((stack1 = (depth0 != null ? depth0.prefill : depth0)) != null ? stack1.username : stack1), depth0)) != null ? stack1 : "")
-    + "\">\n        </div>\n        <div class=\"form-group\">\n            <label for=\"password\" data-i18n=\"login/index.hbs\">Passwort</label>\n            <input type=\"password\" class=\"form-control\" name=\"password\">\n        </div>\n        <div class=\"checkbox\">\n            <label>\n                <input type=\"checkbox\" name=\"remember\"> <span data-i18n=\"login/index.hbs\">Mich erinnerne</span>\n            </label>\n        </div>\n        <button type=\"submit\" class=\"login__submit btn btn-block btn-primary\" data-i18n=\"login/index.hbs\">Login</button>\n        <p class=\"text-center small\"><a href=\"#login/forgot\" data-i18n=\"login/index.hbs\">Passwort vergessen</a></p>\n      </form>\n    </div>\n\n  </div>\n</div>\n\n<footer class=\""
+    + "\" placeholder=\"Ihre E-Mail-Adresse\">\n        </div>\n        <div class=\"form-group\">\n            <label for=\"password\" data-i18n=\"login/index.hbs\">Passwort</label>\n            <input type=\"password\" class=\"form-control\" name=\"password\" placeholder=\"Passwort\">\n        </div>\n        <div class=\"checkbox\">\n            <label>\n                <input type=\"checkbox\" name=\"remember\"> <span data-i18n=\"login/index.hbs\">Mich erinnerne</span>\n            </label>\n        </div>\n        <button type=\"submit\" class=\"login__submit btn btn-block btn-primary\" data-i18n=\"login/index.hbs\">Login</button>\n        <p class=\"text-center small\"><a href=\"#login/forgot\" data-i18n=\"login/index.hbs\">Passwort vergessen</a></p>\n      </form>\n    </div>\n\n  </div>\n</div>\n\n<footer class=\""
     + alias3(((helper = (helper = helpers.locale || (depth0 != null ? depth0.locale : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"locale","hash":{},"data":data}) : helper)))
     + "\">\n  Language: <a class=\"de\" href=\"../de\">de</a> | <a class=\"en\" href=\"../en\">en</a> | <a class=\"es\" href=\"../es\">es</a>\n</footer>\n";
 },"useData":true});
 
-},{"hbsfy/runtime":14}],6:[function(require,module,exports){
+},{"hbsfy/runtime":15}],6:[function(require,module,exports){
 var i18n = require("./../i18n/de/de.js")
 var tpl = require('./index.hbs')
 
@@ -104,61 +105,87 @@ document.body.innerHTML = tpl({
 })
 
 },{"./../i18n/de/de.js":2,"./index.hbs":5}],7:[function(require,module,exports){
-(function (global){
-"use strict";
-/*globals Handlebars: true */
-var base = require("./handlebars/base");
+'use strict';
+
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+
+var _import = require('./handlebars/base');
+
+var base = _interopRequireWildcard(_import);
 
 // Each of these augment the Handlebars object. No need to setup here.
 // (This is done to easily share code between commonjs and browse envs)
-var SafeString = require("./handlebars/safe-string")["default"];
-var Exception = require("./handlebars/exception")["default"];
-var Utils = require("./handlebars/utils");
-var runtime = require("./handlebars/runtime");
+
+var _SafeString = require('./handlebars/safe-string');
+
+var _SafeString2 = _interopRequireWildcard(_SafeString);
+
+var _Exception = require('./handlebars/exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var _import2 = require('./handlebars/utils');
+
+var Utils = _interopRequireWildcard(_import2);
+
+var _import3 = require('./handlebars/runtime');
+
+var runtime = _interopRequireWildcard(_import3);
+
+var _noConflict = require('./handlebars/no-conflict');
+
+var _noConflict2 = _interopRequireWildcard(_noConflict);
 
 // For compatibility and usage outside of module systems, make the Handlebars object a namespace
-var create = function() {
+function create() {
   var hb = new base.HandlebarsEnvironment();
 
   Utils.extend(hb, base);
-  hb.SafeString = SafeString;
-  hb.Exception = Exception;
+  hb.SafeString = _SafeString2['default'];
+  hb.Exception = _Exception2['default'];
   hb.Utils = Utils;
   hb.escapeExpression = Utils.escapeExpression;
 
   hb.VM = runtime;
-  hb.template = function(spec) {
+  hb.template = function (spec) {
     return runtime.template(spec, hb);
   };
 
   return hb;
-};
+}
 
-var Handlebars = create();
-Handlebars.create = create;
+var inst = create();
+inst.create = create;
 
-/*jshint -W040 */
-/* istanbul ignore next */
-var root = typeof global !== 'undefined' ? global : window,
-    $Handlebars = root.Handlebars;
-/* istanbul ignore next */
-Handlebars.noConflict = function() {
-  if (root.Handlebars === Handlebars) {
-    root.Handlebars = $Handlebars;
-  }
-};
+_noConflict2['default'](inst);
 
-Handlebars['default'] = Handlebars;
+inst['default'] = inst;
 
-exports["default"] = Handlebars;
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./handlebars/base":8,"./handlebars/exception":9,"./handlebars/runtime":10,"./handlebars/safe-string":11,"./handlebars/utils":12}],8:[function(require,module,exports){
-"use strict";
-var Utils = require("./utils");
-var Exception = require("./exception")["default"];
+exports['default'] = inst;
+module.exports = exports['default'];
+},{"./handlebars/base":8,"./handlebars/exception":9,"./handlebars/no-conflict":10,"./handlebars/runtime":11,"./handlebars/safe-string":12,"./handlebars/utils":13}],8:[function(require,module,exports){
+'use strict';
 
-var VERSION = "3.0.1";
-exports.VERSION = VERSION;var COMPILER_REVISION = 6;
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+exports.HandlebarsEnvironment = HandlebarsEnvironment;
+exports.createFrame = createFrame;
+
+var _import = require('./utils');
+
+var Utils = _interopRequireWildcard(_import);
+
+var _Exception = require('./exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var VERSION = '3.0.1';
+exports.VERSION = VERSION;
+var COMPILER_REVISION = 6;
+
 exports.COMPILER_REVISION = COMPILER_REVISION;
 var REVISION_CHANGES = {
   1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
@@ -168,6 +195,7 @@ var REVISION_CHANGES = {
   5: '== 2.0.0-alpha.x',
   6: '>= 2.0.0-beta.1'
 };
+
 exports.REVISION_CHANGES = REVISION_CHANGES;
 var isArray = Utils.isArray,
     isFunction = Utils.isFunction,
@@ -181,60 +209,62 @@ function HandlebarsEnvironment(helpers, partials) {
   registerDefaultHelpers(this);
 }
 
-exports.HandlebarsEnvironment = HandlebarsEnvironment;HandlebarsEnvironment.prototype = {
+HandlebarsEnvironment.prototype = {
   constructor: HandlebarsEnvironment,
 
   logger: logger,
   log: log,
 
-  registerHelper: function(name, fn) {
+  registerHelper: function registerHelper(name, fn) {
     if (toString.call(name) === objectType) {
-      if (fn) { throw new Exception('Arg not supported with multiple helpers'); }
+      if (fn) {
+        throw new _Exception2['default']('Arg not supported with multiple helpers');
+      }
       Utils.extend(this.helpers, name);
     } else {
       this.helpers[name] = fn;
     }
   },
-  unregisterHelper: function(name) {
+  unregisterHelper: function unregisterHelper(name) {
     delete this.helpers[name];
   },
 
-  registerPartial: function(name, partial) {
+  registerPartial: function registerPartial(name, partial) {
     if (toString.call(name) === objectType) {
-      Utils.extend(this.partials,  name);
+      Utils.extend(this.partials, name);
     } else {
       if (typeof partial === 'undefined') {
-        throw new Exception('Attempting to register a partial as undefined');
+        throw new _Exception2['default']('Attempting to register a partial as undefined');
       }
       this.partials[name] = partial;
     }
   },
-  unregisterPartial: function(name) {
+  unregisterPartial: function unregisterPartial(name) {
     delete this.partials[name];
   }
 };
 
 function registerDefaultHelpers(instance) {
-  instance.registerHelper('helperMissing', function(/* [args, ]options */) {
-    if(arguments.length === 1) {
+  instance.registerHelper('helperMissing', function () {
+    if (arguments.length === 1) {
       // A missing field in a {{foo}} constuct.
       return undefined;
     } else {
       // Someone is actually trying to call something, blow up.
-      throw new Exception("Missing helper: '" + arguments[arguments.length-1].name + "'");
+      throw new _Exception2['default']('Missing helper: "' + arguments[arguments.length - 1].name + '"');
     }
   });
 
-  instance.registerHelper('blockHelperMissing', function(context, options) {
+  instance.registerHelper('blockHelperMissing', function (context, options) {
     var inverse = options.inverse,
         fn = options.fn;
 
-    if(context === true) {
+    if (context === true) {
       return fn(this);
-    } else if(context === false || context == null) {
+    } else if (context === false || context == null) {
       return inverse(this);
     } else if (isArray(context)) {
-      if(context.length > 0) {
+      if (context.length > 0) {
         if (options.ids) {
           options.ids = [options.name];
         }
@@ -247,102 +277,111 @@ function registerDefaultHelpers(instance) {
       if (options.data && options.ids) {
         var data = createFrame(options.data);
         data.contextPath = Utils.appendContextPath(options.data.contextPath, options.name);
-        options = {data: data};
+        options = { data: data };
       }
 
       return fn(context, options);
     }
   });
 
-  instance.registerHelper('each', function(context, options) {
+  instance.registerHelper('each', function (context, options) {
     if (!options) {
-      throw new Exception('Must pass iterator to #each');
+      throw new _Exception2['default']('Must pass iterator to #each');
     }
 
-    var fn = options.fn, inverse = options.inverse;
-    var i = 0, ret = "", data;
+    var fn = options.fn,
+        inverse = options.inverse,
+        i = 0,
+        ret = '',
+        data = undefined,
+        contextPath = undefined;
 
-    var contextPath;
     if (options.data && options.ids) {
       contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
     }
 
-    if (isFunction(context)) { context = context.call(this); }
+    if (isFunction(context)) {
+      context = context.call(this);
+    }
 
     if (options.data) {
       data = createFrame(options.data);
     }
 
-    function execIteration(key, i, last) {
+    function execIteration(field, index, last) {
       if (data) {
-        data.key = key;
-        data.index = i;
-        data.first = i === 0;
-        data.last  = !!last;
+        data.key = field;
+        data.index = index;
+        data.first = index === 0;
+        data.last = !!last;
 
         if (contextPath) {
-          data.contextPath = contextPath + key;
+          data.contextPath = contextPath + field;
         }
       }
 
-      ret = ret + fn(context[key], {
+      ret = ret + fn(context[field], {
         data: data,
-        blockParams: Utils.blockParams([context[key], key], [contextPath + key, null])
+        blockParams: Utils.blockParams([context[field], field], [contextPath + field, null])
       });
     }
 
-    if(context && typeof context === 'object') {
+    if (context && typeof context === 'object') {
       if (isArray(context)) {
-        for(var j = context.length; i<j; i++) {
-          execIteration(i, i, i === context.length-1);
+        for (var j = context.length; i < j; i++) {
+          execIteration(i, i, i === context.length - 1);
         }
       } else {
-        var priorKey;
+        var priorKey = undefined;
 
-        for(var key in context) {
-          if(context.hasOwnProperty(key)) {
+        for (var key in context) {
+          if (context.hasOwnProperty(key)) {
             // We're running the iterations one step out of sync so we can detect
             // the last iteration without have to scan the object twice and create
-            // an itermediate keys array. 
+            // an itermediate keys array.
             if (priorKey) {
-              execIteration(priorKey, i-1);
+              execIteration(priorKey, i - 1);
             }
             priorKey = key;
             i++;
           }
         }
         if (priorKey) {
-          execIteration(priorKey, i-1, true);
+          execIteration(priorKey, i - 1, true);
         }
       }
     }
 
-    if(i === 0){
+    if (i === 0) {
       ret = inverse(this);
     }
 
     return ret;
   });
 
-  instance.registerHelper('if', function(conditional, options) {
-    if (isFunction(conditional)) { conditional = conditional.call(this); }
+  instance.registerHelper('if', function (conditional, options) {
+    if (isFunction(conditional)) {
+      conditional = conditional.call(this);
+    }
 
     // Default behavior is to render the positive path if the value is truthy and not empty.
     // The `includeZero` option may be set to treat the condtional as purely not empty based on the
     // behavior of isEmpty. Effectively this determines if 0 is handled by the positive path or negative.
-    if ((!options.hash.includeZero && !conditional) || Utils.isEmpty(conditional)) {
+    if (!options.hash.includeZero && !conditional || Utils.isEmpty(conditional)) {
       return options.inverse(this);
     } else {
       return options.fn(this);
     }
   });
 
-  instance.registerHelper('unless', function(conditional, options) {
-    return instance.helpers['if'].call(this, conditional, {fn: options.inverse, inverse: options.fn, hash: options.hash});
+  instance.registerHelper('unless', function (conditional, options) {
+    return instance.helpers['if'].call(this, conditional, { fn: options.inverse, inverse: options.fn, hash: options.hash });
   });
 
-  instance.registerHelper('with', function(context, options) {
-    if (isFunction(context)) { context = context.call(this); }
+  instance.registerHelper('with', function (context, options) {
+    if (isFunction(context)) {
+      context = context.call(this);
+    }
 
     var fn = options.fn;
 
@@ -350,7 +389,7 @@ function registerDefaultHelpers(instance) {
       if (options.data && options.ids) {
         var data = createFrame(options.data);
         data.contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]);
-        options = {data:data};
+        options = { data: data };
       }
 
       return fn(context, options);
@@ -359,12 +398,12 @@ function registerDefaultHelpers(instance) {
     }
   });
 
-  instance.registerHelper('log', function(message, options) {
+  instance.registerHelper('log', function (message, options) {
     var level = options.data && options.data.level != null ? parseInt(options.data.level, 10) : 1;
     instance.log(level, message);
   });
 
-  instance.registerHelper('lookup', function(obj, field) {
+  instance.registerHelper('lookup', function (obj, field) {
     return obj && obj[field];
   });
 }
@@ -380,31 +419,37 @@ var logger = {
   level: 1,
 
   // Can be overridden in the host environment
-  log: function(level, message) {
+  log: function log(level, message) {
     if (typeof console !== 'undefined' && logger.level <= level) {
       var method = logger.methodMap[level];
-      (console[method] || console.log).call(console, message);
+      (console[method] || console.log).call(console, message); // eslint-disable-line no-console
     }
   }
 };
+
 exports.logger = logger;
 var log = logger.log;
+
 exports.log = log;
-var createFrame = function(object) {
+
+function createFrame(object) {
   var frame = Utils.extend({}, object);
   frame._parent = object;
   return frame;
-};
-exports.createFrame = createFrame;
-},{"./exception":9,"./utils":12}],9:[function(require,module,exports){
-"use strict";
+}
+
+/* [args, ]options */
+},{"./exception":9,"./utils":13}],9:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
 
 var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
 
 function Exception(message, node) {
   var loc = node && node.loc,
-      line,
-      column;
+      line = undefined,
+      column = undefined;
   if (loc) {
     line = loc.start.line;
     column = loc.start.column;
@@ -419,6 +464,10 @@ function Exception(message, node) {
     this[errorProps[idx]] = tmp[errorProps[idx]];
   }
 
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, Exception);
+  }
+
   if (loc) {
     this.lineNumber = line;
     this.column = column;
@@ -427,49 +476,85 @@ function Exception(message, node) {
 
 Exception.prototype = new Error();
 
-exports["default"] = Exception;
+exports['default'] = Exception;
+module.exports = exports['default'];
 },{}],10:[function(require,module,exports){
-"use strict";
-var Utils = require("./utils");
-var Exception = require("./exception")["default"];
-var COMPILER_REVISION = require("./base").COMPILER_REVISION;
-var REVISION_CHANGES = require("./base").REVISION_CHANGES;
-var createFrame = require("./base").createFrame;
+(function (global){
+'use strict';
+
+exports.__esModule = true;
+/*global window */
+
+exports['default'] = function (Handlebars) {
+  /* istanbul ignore next */
+  var root = typeof global !== 'undefined' ? global : window,
+      $Handlebars = root.Handlebars;
+  /* istanbul ignore next */
+  Handlebars.noConflict = function () {
+    if (root.Handlebars === Handlebars) {
+      root.Handlebars = $Handlebars;
+    }
+  };
+};
+
+module.exports = exports['default'];
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],11:[function(require,module,exports){
+'use strict';
+
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+exports.checkRevision = checkRevision;
+
+// TODO: Remove this line and break up compilePartial
+
+exports.template = template;
+exports.wrapProgram = wrapProgram;
+exports.resolvePartial = resolvePartial;
+exports.invokePartial = invokePartial;
+exports.noop = noop;
+
+var _import = require('./utils');
+
+var Utils = _interopRequireWildcard(_import);
+
+var _Exception = require('./exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var _COMPILER_REVISION$REVISION_CHANGES$createFrame = require('./base');
 
 function checkRevision(compilerInfo) {
   var compilerRevision = compilerInfo && compilerInfo[0] || 1,
-      currentRevision = COMPILER_REVISION;
+      currentRevision = _COMPILER_REVISION$REVISION_CHANGES$createFrame.COMPILER_REVISION;
 
   if (compilerRevision !== currentRevision) {
     if (compilerRevision < currentRevision) {
-      var runtimeVersions = REVISION_CHANGES[currentRevision],
-          compilerVersions = REVISION_CHANGES[compilerRevision];
-      throw new Exception("Template was precompiled with an older version of Handlebars than the current runtime. "+
-            "Please update your precompiler to a newer version ("+runtimeVersions+") or downgrade your runtime to an older version ("+compilerVersions+").");
+      var runtimeVersions = _COMPILER_REVISION$REVISION_CHANGES$createFrame.REVISION_CHANGES[currentRevision],
+          compilerVersions = _COMPILER_REVISION$REVISION_CHANGES$createFrame.REVISION_CHANGES[compilerRevision];
+      throw new _Exception2['default']('Template was precompiled with an older version of Handlebars than the current runtime. ' + 'Please update your precompiler to a newer version (' + runtimeVersions + ') or downgrade your runtime to an older version (' + compilerVersions + ').');
     } else {
       // Use the embedded version info since the runtime doesn't know about this revision yet
-      throw new Exception("Template was precompiled with a newer version of Handlebars than the current runtime. "+
-            "Please update your runtime to a newer version ("+compilerInfo[1]+").");
+      throw new _Exception2['default']('Template was precompiled with a newer version of Handlebars than the current runtime. ' + 'Please update your runtime to a newer version (' + compilerInfo[1] + ').');
     }
   }
 }
 
-exports.checkRevision = checkRevision;// TODO: Remove this line and break up compilePartial
-
 function template(templateSpec, env) {
   /* istanbul ignore next */
   if (!env) {
-    throw new Exception("No environment passed to template");
+    throw new _Exception2['default']('No environment passed to template');
   }
   if (!templateSpec || !templateSpec.main) {
-    throw new Exception('Unknown template object: ' + typeof templateSpec);
+    throw new _Exception2['default']('Unknown template object: ' + typeof templateSpec);
   }
 
   // Note: Using env.VM references rather than local var references throughout this section to allow
   // for external users to override these as psuedo-supported APIs.
   env.VM.checkRevision(templateSpec.compiler);
 
-  var invokePartialWrapper = function(partial, context, options) {
+  function invokePartialWrapper(partial, context, options) {
     if (options.hash) {
       context = Utils.extend({}, context, options.hash);
     }
@@ -495,19 +580,19 @@ function template(templateSpec, env) {
       }
       return result;
     } else {
-      throw new Exception("The partial " + options.name + " could not be compiled when running in runtime-only mode");
+      throw new _Exception2['default']('The partial ' + options.name + ' could not be compiled when running in runtime-only mode');
     }
-  };
+  }
 
   // Just add water
   var container = {
-    strict: function(obj, name) {
+    strict: function strict(obj, name) {
       if (!(name in obj)) {
-        throw new Exception('"' + name + '" not defined in ' + obj);
+        throw new _Exception2['default']('"' + name + '" not defined in ' + obj);
       }
       return obj[name];
     },
-    lookup: function(depths, name) {
+    lookup: function lookup(depths, name) {
       var len = depths.length;
       for (var i = 0; i < len; i++) {
         if (depths[i] && depths[i][name] != null) {
@@ -515,68 +600,69 @@ function template(templateSpec, env) {
         }
       }
     },
-    lambda: function(current, context) {
+    lambda: function lambda(current, context) {
       return typeof current === 'function' ? current.call(context) : current;
     },
 
     escapeExpression: Utils.escapeExpression,
     invokePartial: invokePartialWrapper,
 
-    fn: function(i) {
+    fn: function fn(i) {
       return templateSpec[i];
     },
 
     programs: [],
-    program: function(i, data, declaredBlockParams, blockParams, depths) {
+    program: function program(i, data, declaredBlockParams, blockParams, depths) {
       var programWrapper = this.programs[i],
           fn = this.fn(i);
       if (data || depths || blockParams || declaredBlockParams) {
-        programWrapper = program(this, i, fn, data, declaredBlockParams, blockParams, depths);
+        programWrapper = wrapProgram(this, i, fn, data, declaredBlockParams, blockParams, depths);
       } else if (!programWrapper) {
-        programWrapper = this.programs[i] = program(this, i, fn);
+        programWrapper = this.programs[i] = wrapProgram(this, i, fn);
       }
       return programWrapper;
     },
 
-    data: function(data, depth) {
-      while (data && depth--) {
-        data = data._parent;
+    data: function data(value, depth) {
+      while (value && depth--) {
+        value = value._parent;
       }
-      return data;
+      return value;
     },
-    merge: function(param, common) {
-      var ret = param || common;
+    merge: function merge(param, common) {
+      var obj = param || common;
 
-      if (param && common && (param !== common)) {
-        ret = Utils.extend({}, common, param);
+      if (param && common && param !== common) {
+        obj = Utils.extend({}, common, param);
       }
 
-      return ret;
+      return obj;
     },
 
     noop: env.VM.noop,
     compilerInfo: templateSpec.compiler
   };
 
-  var ret = function(context, options) {
-    options = options || {};
+  function ret(context) {
+    var options = arguments[1] === undefined ? {} : arguments[1];
+
     var data = options.data;
 
     ret._setup(options);
     if (!options.partial && templateSpec.useData) {
       data = initData(context, data);
     }
-    var depths,
+    var depths = undefined,
         blockParams = templateSpec.useBlockParams ? [] : undefined;
     if (templateSpec.useDepths) {
       depths = options.depths ? [context].concat(options.depths) : [context];
     }
 
     return templateSpec.main.call(container, context, container.helpers, container.partials, data, blockParams, depths);
-  };
+  }
   ret.isTop = true;
 
-  ret._setup = function(options) {
+  ret._setup = function (options) {
     if (!options.partial) {
       container.helpers = container.merge(options.helpers, env.helpers);
 
@@ -589,37 +675,32 @@ function template(templateSpec, env) {
     }
   };
 
-  ret._child = function(i, data, blockParams, depths) {
+  ret._child = function (i, data, blockParams, depths) {
     if (templateSpec.useBlockParams && !blockParams) {
-      throw new Exception('must pass block params');
+      throw new _Exception2['default']('must pass block params');
     }
     if (templateSpec.useDepths && !depths) {
-      throw new Exception('must pass parent depths');
+      throw new _Exception2['default']('must pass parent depths');
     }
 
-    return program(container, i, templateSpec[i], data, 0, blockParams, depths);
+    return wrapProgram(container, i, templateSpec[i], data, 0, blockParams, depths);
   };
   return ret;
 }
 
-exports.template = template;function program(container, i, fn, data, declaredBlockParams, blockParams, depths) {
-  var prog = function(context, options) {
-    options = options || {};
+function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, depths) {
+  function prog(context) {
+    var options = arguments[1] === undefined ? {} : arguments[1];
 
-    return fn.call(container,
-        context,
-        container.helpers, container.partials,
-        options.data || data,
-        blockParams && [options.blockParams].concat(blockParams),
-        depths && [context].concat(depths));
-  };
+    return fn.call(container, context, container.helpers, container.partials, options.data || data, blockParams && [options.blockParams].concat(blockParams), depths && [context].concat(depths));
+  }
   prog.program = i;
   prog.depth = depths ? depths.length : 0;
   prog.blockParams = declaredBlockParams || 0;
   return prog;
 }
 
-exports.program = program;function resolvePartial(partial, context, options) {
+function resolvePartial(partial, context, options) {
   if (!partial) {
     partial = options.partials[options.name];
   } else if (!partial.call && !options.name) {
@@ -630,51 +711,65 @@ exports.program = program;function resolvePartial(partial, context, options) {
   return partial;
 }
 
-exports.resolvePartial = resolvePartial;function invokePartial(partial, context, options) {
+function invokePartial(partial, context, options) {
   options.partial = true;
 
-  if(partial === undefined) {
-    throw new Exception("The partial " + options.name + " could not be found");
-  } else if(partial instanceof Function) {
+  if (partial === undefined) {
+    throw new _Exception2['default']('The partial ' + options.name + ' could not be found');
+  } else if (partial instanceof Function) {
     return partial(context, options);
   }
 }
 
-exports.invokePartial = invokePartial;function noop() { return ""; }
+function noop() {
+  return '';
+}
 
-exports.noop = noop;function initData(context, data) {
+function initData(context, data) {
   if (!data || !('root' in data)) {
-    data = data ? createFrame(data) : {};
+    data = data ? _COMPILER_REVISION$REVISION_CHANGES$createFrame.createFrame(data) : {};
     data.root = context;
   }
   return data;
 }
-},{"./base":8,"./exception":9,"./utils":12}],11:[function(require,module,exports){
-"use strict";
+},{"./base":8,"./exception":9,"./utils":13}],12:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
 // Build out our basic SafeString type
 function SafeString(string) {
   this.string = string;
 }
 
-SafeString.prototype.toString = SafeString.prototype.toHTML = function() {
-  return "" + this.string;
+SafeString.prototype.toString = SafeString.prototype.toHTML = function () {
+  return '' + this.string;
 };
 
-exports["default"] = SafeString;
-},{}],12:[function(require,module,exports){
-"use strict";
-/*jshint -W004 */
+exports['default'] = SafeString;
+module.exports = exports['default'];
+},{}],13:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
+exports.extend = extend;
+
+// Older IE versions do not directly support indexOf so we must implement our own, sadly.
+exports.indexOf = indexOf;
+exports.escapeExpression = escapeExpression;
+exports.isEmpty = isEmpty;
+exports.blockParams = blockParams;
+exports.appendContextPath = appendContextPath;
 var escape = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&#x27;",
-  "`": "&#x60;"
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  '\'': '&#x27;',
+  '`': '&#x60;'
 };
 
-var badChars = /[&<>"'`]/g;
-var possible = /[&<>"'`]/;
+var badChars = /[&<>"'`]/g,
+    possible = /[&<>"'`]/;
 
 function escapeChar(chr) {
   return escape[chr];
@@ -692,28 +787,31 @@ function extend(obj /* , ...source */) {
   return obj;
 }
 
-exports.extend = extend;var toString = Object.prototype.toString;
+var toString = Object.prototype.toString;
+
 exports.toString = toString;
 // Sourced from lodash
 // https://github.com/bestiejs/lodash/blob/master/LICENSE.txt
-var isFunction = function(value) {
+/*eslint-disable func-style, no-var */
+var isFunction = function isFunction(value) {
   return typeof value === 'function';
 };
 // fallback for older versions of Chrome and Safari
 /* istanbul ignore next */
 if (isFunction(/x/)) {
-  isFunction = function(value) {
+  exports.isFunction = isFunction = function (value) {
     return typeof value === 'function' && toString.call(value) === '[object Function]';
   };
 }
 var isFunction;
 exports.isFunction = isFunction;
+/*eslint-enable func-style, no-var */
+
 /* istanbul ignore next */
-var isArray = Array.isArray || function(value) {
-  return (value && typeof value === 'object') ? toString.call(value) === '[object Array]' : false;
-};
-exports.isArray = isArray;
-// Older IE versions do not directly support indexOf so we must implement our own, sadly.
+var isArray = Array.isArray || function (value) {
+  return value && typeof value === 'object' ? toString.call(value) === '[object Array]' : false;
+};exports.isArray = isArray;
+
 function indexOf(array, value) {
   for (var i = 0, len = array.length; i < len; i++) {
     if (array[i] === value) {
@@ -723,7 +821,6 @@ function indexOf(array, value) {
   return -1;
 }
 
-exports.indexOf = indexOf;
 function escapeExpression(string) {
   if (typeof string !== 'string') {
     // don't escape SafeStrings, since they're already safe
@@ -741,11 +838,13 @@ function escapeExpression(string) {
     string = '' + string;
   }
 
-  if (!possible.test(string)) { return string; }
+  if (!possible.test(string)) {
+    return string;
+  }
   return string.replace(badChars, escapeChar);
 }
 
-exports.escapeExpression = escapeExpression;function isEmpty(value) {
+function isEmpty(value) {
   if (!value && value !== 0) {
     return true;
   } else if (isArray(value) && value.length === 0) {
@@ -755,25 +854,23 @@ exports.escapeExpression = escapeExpression;function isEmpty(value) {
   }
 }
 
-exports.isEmpty = isEmpty;function blockParams(params, ids) {
+function blockParams(params, ids) {
   params.path = ids;
   return params;
 }
 
-exports.blockParams = blockParams;function appendContextPath(contextPath, id) {
+function appendContextPath(contextPath, id) {
   return (contextPath ? contextPath + '.' : '') + id;
 }
-
-exports.appendContextPath = appendContextPath;
-},{}],13:[function(require,module,exports){
+},{}],14:[function(require,module,exports){
 // Create a simple path alias to allow browserify to resolve
 // the runtime on a supported path.
 module.exports = require('./dist/cjs/handlebars.runtime')['default'];
 
-},{"./dist/cjs/handlebars.runtime":7}],14:[function(require,module,exports){
+},{"./dist/cjs/handlebars.runtime":7}],15:[function(require,module,exports){
 module.exports = require("handlebars/runtime")["default"];
 
-},{"handlebars/runtime":13}],15:[function(require,module,exports){
+},{"handlebars/runtime":14}],16:[function(require,module,exports){
 /**
  * @preserve jed.js https://github.com/SlexAxton/Jed
  */
@@ -1797,7 +1894,7 @@ return parser;
 
 })(this);
 
-},{}],16:[function(require,module,exports){
+},{}],17:[function(require,module,exports){
 //! moment.js locale configuration
 //! locale : german (de)
 //! author : lluchs : https://github.com/lluchs
@@ -1872,9 +1969,9 @@ return parser;
     return de;
 
 }));
-},{"../moment":17}],17:[function(require,module,exports){
+},{"../moment":18}],18:[function(require,module,exports){
 //! moment.js
-//! version : 2.10.2
+//! version : 2.10.3
 //! authors : Tim Wood, Iskren Chernev, Moment.js contributors
 //! license : MIT
 //! momentjs.com
@@ -1897,28 +1994,12 @@ return parser;
         hookCallback = callback;
     }
 
-    function defaultParsingFlags() {
-        // We need to deep clone this object.
-        return {
-            empty           : false,
-            unusedTokens    : [],
-            unusedInput     : [],
-            overflow        : -2,
-            charsLeftOver   : 0,
-            nullInput       : false,
-            invalidMonth    : null,
-            invalidFormat   : false,
-            userInvalidated : false,
-            iso             : false
-        };
-    }
-
     function isArray(input) {
         return Object.prototype.toString.call(input) === '[object Array]';
     }
 
     function isDate(input) {
-        return Object.prototype.toString.call(input) === '[object Date]' || input instanceof Date;
+        return input instanceof Date || Object.prototype.toString.call(input) === '[object Date]';
     }
 
     function map(arr, fn) {
@@ -1955,21 +2036,45 @@ return parser;
         return createLocalOrUTC(input, format, locale, strict, true).utc();
     }
 
+    function defaultParsingFlags() {
+        // We need to deep clone this object.
+        return {
+            empty           : false,
+            unusedTokens    : [],
+            unusedInput     : [],
+            overflow        : -2,
+            charsLeftOver   : 0,
+            nullInput       : false,
+            invalidMonth    : null,
+            invalidFormat   : false,
+            userInvalidated : false,
+            iso             : false
+        };
+    }
+
+    function getParsingFlags(m) {
+        if (m._pf == null) {
+            m._pf = defaultParsingFlags();
+        }
+        return m._pf;
+    }
+
     function valid__isValid(m) {
         if (m._isValid == null) {
+            var flags = getParsingFlags(m);
             m._isValid = !isNaN(m._d.getTime()) &&
-                m._pf.overflow < 0 &&
-                !m._pf.empty &&
-                !m._pf.invalidMonth &&
-                !m._pf.nullInput &&
-                !m._pf.invalidFormat &&
-                !m._pf.userInvalidated;
+                flags.overflow < 0 &&
+                !flags.empty &&
+                !flags.invalidMonth &&
+                !flags.nullInput &&
+                !flags.invalidFormat &&
+                !flags.userInvalidated;
 
             if (m._strict) {
                 m._isValid = m._isValid &&
-                    m._pf.charsLeftOver === 0 &&
-                    m._pf.unusedTokens.length === 0 &&
-                    m._pf.bigHour === undefined;
+                    flags.charsLeftOver === 0 &&
+                    flags.unusedTokens.length === 0 &&
+                    flags.bigHour === undefined;
             }
         }
         return m._isValid;
@@ -1978,10 +2083,10 @@ return parser;
     function valid__createInvalid (flags) {
         var m = create_utc__createUTC(NaN);
         if (flags != null) {
-            extend(m._pf, flags);
+            extend(getParsingFlags(m), flags);
         }
         else {
-            m._pf.userInvalidated = true;
+            getParsingFlags(m).userInvalidated = true;
         }
 
         return m;
@@ -2017,7 +2122,7 @@ return parser;
             to._offset = from._offset;
         }
         if (typeof from._pf !== 'undefined') {
-            to._pf = from._pf;
+            to._pf = getParsingFlags(from);
         }
         if (typeof from._locale !== 'undefined') {
             to._locale = from._locale;
@@ -2052,7 +2157,7 @@ return parser;
     }
 
     function isMoment (obj) {
-        return obj instanceof Moment || (obj != null && hasOwnProp(obj, '_isAMomentObject'));
+        return obj instanceof Moment || (obj != null && obj._isAMomentObject != null);
     }
 
     function toInt(argumentForCoercion) {
@@ -2490,7 +2595,7 @@ return parser;
         if (month != null) {
             array[MONTH] = month;
         } else {
-            config._pf.invalidMonth = input;
+            getParsingFlags(config).invalidMonth = input;
         }
     });
 
@@ -2574,7 +2679,7 @@ return parser;
         var overflow;
         var a = m._a;
 
-        if (a && m._pf.overflow === -2) {
+        if (a && getParsingFlags(m).overflow === -2) {
             overflow =
                 a[MONTH]       < 0 || a[MONTH]       > 11  ? MONTH :
                 a[DATE]        < 1 || a[DATE]        > daysInMonth(a[YEAR], a[MONTH]) ? DATE :
@@ -2584,11 +2689,11 @@ return parser;
                 a[MILLISECOND] < 0 || a[MILLISECOND] > 999 ? MILLISECOND :
                 -1;
 
-            if (m._pf._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
+            if (getParsingFlags(m)._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
                 overflow = DATE;
             }
 
-            m._pf.overflow = overflow;
+            getParsingFlags(m).overflow = overflow;
         }
 
         return m;
@@ -2601,10 +2706,12 @@ return parser;
     }
 
     function deprecate(msg, fn) {
-        var firstTime = true;
+        var firstTime = true,
+            msgWithStack = msg + '\n' + (new Error()).stack;
+
         return extend(function () {
             if (firstTime) {
-                warn(msg);
+                warn(msgWithStack);
                 firstTime = false;
             }
             return fn.apply(this, arguments);
@@ -2649,7 +2756,7 @@ return parser;
             match = from_string__isoRegex.exec(string);
 
         if (match) {
-            config._pf.iso = true;
+            getParsingFlags(config).iso = true;
             for (i = 0, l = isoDates.length; i < l; i++) {
                 if (isoDates[i][1].exec(string)) {
                     // match[5] should be 'T' or undefined
@@ -2929,7 +3036,7 @@ return parser;
             yearToUse = defaults(config._a[YEAR], currentDate[YEAR]);
 
             if (config._dayOfYear > daysInYear(yearToUse)) {
-                config._pf._overflowDayOfYear = true;
+                getParsingFlags(config)._overflowDayOfYear = true;
             }
 
             date = createUTCDate(yearToUse, 0, config._dayOfYear);
@@ -3025,7 +3132,7 @@ return parser;
         }
 
         config._a = [];
-        config._pf.empty = true;
+        getParsingFlags(config).empty = true;
 
         // This array is used to make a Date, either with `new Date` or `Date.UTC`
         var string = '' + config._i,
@@ -3041,7 +3148,7 @@ return parser;
             if (parsedInput) {
                 skipped = string.substr(0, string.indexOf(parsedInput));
                 if (skipped.length > 0) {
-                    config._pf.unusedInput.push(skipped);
+                    getParsingFlags(config).unusedInput.push(skipped);
                 }
                 string = string.slice(string.indexOf(parsedInput) + parsedInput.length);
                 totalParsedInputLength += parsedInput.length;
@@ -3049,27 +3156,29 @@ return parser;
             // don't parse if it's not a known token
             if (formatTokenFunctions[token]) {
                 if (parsedInput) {
-                    config._pf.empty = false;
+                    getParsingFlags(config).empty = false;
                 }
                 else {
-                    config._pf.unusedTokens.push(token);
+                    getParsingFlags(config).unusedTokens.push(token);
                 }
                 addTimeToArrayFromToken(token, parsedInput, config);
             }
             else if (config._strict && !parsedInput) {
-                config._pf.unusedTokens.push(token);
+                getParsingFlags(config).unusedTokens.push(token);
             }
         }
 
         // add remaining unparsed input length to the string
-        config._pf.charsLeftOver = stringLength - totalParsedInputLength;
+        getParsingFlags(config).charsLeftOver = stringLength - totalParsedInputLength;
         if (string.length > 0) {
-            config._pf.unusedInput.push(string);
+            getParsingFlags(config).unusedInput.push(string);
         }
 
         // clear _12h flag if hour is <= 12
-        if (config._pf.bigHour === true && config._a[HOUR] <= 12) {
-            config._pf.bigHour = undefined;
+        if (getParsingFlags(config).bigHour === true &&
+                config._a[HOUR] <= 12 &&
+                config._a[HOUR] > 0) {
+            getParsingFlags(config).bigHour = undefined;
         }
         // handle meridiem
         config._a[HOUR] = meridiemFixWrap(config._locale, config._a[HOUR], config._meridiem);
@@ -3113,7 +3222,7 @@ return parser;
             currentScore;
 
         if (config._f.length === 0) {
-            config._pf.invalidFormat = true;
+            getParsingFlags(config).invalidFormat = true;
             config._d = new Date(NaN);
             return;
         }
@@ -3124,7 +3233,6 @@ return parser;
             if (config._useUTC != null) {
                 tempConfig._useUTC = config._useUTC;
             }
-            tempConfig._pf = defaultParsingFlags();
             tempConfig._f = config._f[i];
             configFromStringAndFormat(tempConfig);
 
@@ -3133,12 +3241,12 @@ return parser;
             }
 
             // if there is any input that was not parsed add a penalty for that format
-            currentScore += tempConfig._pf.charsLeftOver;
+            currentScore += getParsingFlags(tempConfig).charsLeftOver;
 
             //or tokens
-            currentScore += tempConfig._pf.unusedTokens.length * 10;
+            currentScore += getParsingFlags(tempConfig).unusedTokens.length * 10;
 
-            tempConfig._pf.score = currentScore;
+            getParsingFlags(tempConfig).score = currentScore;
 
             if (scoreToBeat == null || currentScore < scoreToBeat) {
                 scoreToBeat = currentScore;
@@ -3181,6 +3289,8 @@ return parser;
             configFromStringAndArray(config);
         } else if (format) {
             configFromStringAndFormat(config);
+        } else if (isDate(input)) {
+            config._d = input;
         } else {
             configFromInput(config);
         }
@@ -3233,7 +3343,6 @@ return parser;
         c._i = input;
         c._f = format;
         c._strict = strict;
-        c._pf = defaultParsingFlags();
 
         return createFromConfig(c);
     }
@@ -3807,11 +3916,25 @@ return parser;
     }
 
     function from (time, withoutSuffix) {
+        if (!this.isValid()) {
+            return this.localeData().invalidDate();
+        }
         return create__createDuration({to: this, from: time}).locale(this.locale()).humanize(!withoutSuffix);
     }
 
     function fromNow (withoutSuffix) {
         return this.from(local__createLocal(), withoutSuffix);
+    }
+
+    function to (time, withoutSuffix) {
+        if (!this.isValid()) {
+            return this.localeData().invalidDate();
+        }
+        return create__createDuration({from: this, to: time}).locale(this.locale()).humanize(!withoutSuffix);
+    }
+
+    function toNow (withoutSuffix) {
+        return this.to(local__createLocal(), withoutSuffix);
     }
 
     function locale (key) {
@@ -3916,11 +4039,11 @@ return parser;
     }
 
     function parsingFlags () {
-        return extend({}, this._pf);
+        return extend({}, getParsingFlags(this));
     }
 
     function invalidAt () {
-        return this._pf.overflow;
+        return getParsingFlags(this).overflow;
     }
 
     addFormatToken(0, ['gg', 2], 0, function () {
@@ -4071,7 +4194,7 @@ return parser;
         if (weekday != null) {
             week.d = weekday;
         } else {
-            config._pf.invalidWeekday = input;
+            getParsingFlags(config).invalidWeekday = input;
         }
     });
 
@@ -4196,7 +4319,7 @@ return parser;
     });
     addParseToken(['h', 'hh'], function (input, array, config) {
         array[HOUR] = toInt(input);
-        config._pf.bigHour = true;
+        getParsingFlags(config).bigHour = true;
     });
 
     // LOCALES
@@ -4313,6 +4436,8 @@ return parser;
     momentPrototype__proto.format       = format;
     momentPrototype__proto.from         = from;
     momentPrototype__proto.fromNow      = fromNow;
+    momentPrototype__proto.to           = to;
+    momentPrototype__proto.toNow        = toNow;
     momentPrototype__proto.get          = getSet;
     momentPrototype__proto.invalidAt    = invalidAt;
     momentPrototype__proto.isAfter      = isAfter;
@@ -4501,7 +4626,7 @@ return parser;
         }
         // Lenient ordinal parsing accepts just a number in addition to
         // number + (possibly) stuff coming from _ordinalParseLenient.
-        this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + /\d{1,2}/.source);
+        this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + (/\d{1,2}/).source);
     }
 
     var prototype__proto = Locale.prototype;
@@ -4718,13 +4843,13 @@ return parser;
             // handle milliseconds separately because of floating point math errors (issue #1867)
             days = this._days + Math.round(yearsToDays(this._months / 12));
             switch (units) {
-                case 'week'   : return days / 7            + milliseconds / 6048e5;
-                case 'day'    : return days                + milliseconds / 864e5;
-                case 'hour'   : return days * 24           + milliseconds / 36e5;
-                case 'minute' : return days * 24 * 60      + milliseconds / 6e4;
-                case 'second' : return days * 24 * 60 * 60 + milliseconds / 1000;
+                case 'week'   : return days / 7     + milliseconds / 6048e5;
+                case 'day'    : return days         + milliseconds / 864e5;
+                case 'hour'   : return days * 24    + milliseconds / 36e5;
+                case 'minute' : return days * 1440  + milliseconds / 6e4;
+                case 'second' : return days * 86400 + milliseconds / 1000;
                 // Math.floor prevents floating point math errors here
-                case 'millisecond': return Math.floor(days * 24 * 60 * 60 * 1000) + milliseconds;
+                case 'millisecond': return Math.floor(days * 864e5) + milliseconds;
                 default: throw new Error('Unknown unit ' + units);
             }
         }
@@ -4925,7 +5050,7 @@ return parser;
     // Side effect imports
 
 
-    utils_hooks__hooks.version = '2.10.2';
+    utils_hooks__hooks.version = '2.10.3';
 
     setHookCallback(local__createLocal);
 

--- a/dist/en/bundle.js
+++ b/dist/en/bundle.js
@@ -8,7 +8,7 @@ Handlebars.registerHelper('ngettext', function (one, other, count) {
 
 require('./login')
 
-},{"./i18n/en/en.js":3,"./login":6,"handlebars/runtime":13}],2:[function(require,module,exports){
+},{"./i18n/en/en.js":3,"./login":6,"handlebars/runtime":14}],2:[function(require,module,exports){
 module.exports={
   "frontend": {
     "" : {
@@ -36,7 +36,7 @@ module.exports = i18n(require('./dict.json'))
 module.exports.moment = require('moment')
 module.exports.locale = 'en'
 
-},{"../i18n.js":4,"./dict.json":2,"moment":16}],4:[function(require,module,exports){
+},{"../i18n.js":4,"./dict.json":2,"moment":17}],4:[function(require,module,exports){
 /*
 # i18n.js - used at run-time & build-time for getext style string translation
 */
@@ -50,7 +50,7 @@ module.exports = function (dict) {
   })
 }
 
-},{"jed":15}],5:[function(require,module,exports){
+},{"jed":16}],5:[function(require,module,exports){
 // hbsfy compiled Handlebars template
 var HandlebarsCompiler = require('hbsfy/runtime');
 module.exports = HandlebarsCompiler.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
@@ -72,12 +72,12 @@ module.exports = HandlebarsCompiler.template({"compiler":[6,">= 2.0.0-beta.1"],"
     + alias3(((helper = (helper = helpers.locale || (depth0 != null ? depth0.locale : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"locale","hash":{},"data":data}) : helper)))
     + "\"></div>\n    </div>\n\n    <div class=\"col-sm-6\">\n      <form class=\"login__form form\">\n        <h3 data-i18n>Login</h3>\n        <p class=\"login__lead\" data-i18n>\n          Please enter your email and password to log in\n        </p>\n        <div class=\"form-group\">\n            <label for=\"username\" data-i18n>Email</label>\n            <input type=\"text\" class=\"form-control\" name=\"username\" autocorrect=\"off\" autocapitalize=\"off\" value=\""
     + ((stack1 = this.lambda(((stack1 = (depth0 != null ? depth0.prefill : depth0)) != null ? stack1.username : stack1), depth0)) != null ? stack1 : "")
-    + "\">\n        </div>\n        <div class=\"form-group\">\n            <label for=\"password\" data-i18n>Password</label>\n            <input type=\"password\" class=\"form-control\" name=\"password\">\n        </div>\n        <div class=\"checkbox\">\n            <label>\n                <input type=\"checkbox\" name=\"remember\"> <span data-i18n>Remember Me</span>\n            </label>\n        </div>\n        <button type=\"submit\" class=\"login__submit btn btn-block btn-primary\" data-i18n>Login</button>\n        <p class=\"text-center small\"><a href=\"#login/forgot\" data-i18n>Forgot your password</a></p>\n      </form>\n    </div>\n\n  </div>\n</div>\n\n<footer class=\""
+    + "\" placeholder=\"Your email address\" data-i18n-attr=\"placeholder\">\n        </div>\n        <div class=\"form-group\">\n            <label for=\"password\" data-i18n>Password</label>\n            <input type=\"password\" class=\"form-control\" name=\"password\" placeholder=\"Password\" data-i18n-attr=\"placeholder\">\n        </div>\n        <div class=\"checkbox\">\n            <label>\n                <input type=\"checkbox\" name=\"remember\"> <span data-i18n>Remember Me</span>\n            </label>\n        </div>\n        <button type=\"submit\" class=\"login__submit btn btn-block btn-primary\" data-i18n>Login</button>\n        <p class=\"text-center small\"><a href=\"#login/forgot\" data-i18n>Forgot your password</a></p>\n      </form>\n    </div>\n\n  </div>\n</div>\n\n<footer class=\""
     + alias3(((helper = (helper = helpers.locale || (depth0 != null ? depth0.locale : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"locale","hash":{},"data":data}) : helper)))
     + "\">\n  Language: <a class=\"de\" href=\"../de\">de</a> | <a class=\"en\" href=\"../en\">en</a> | <a class=\"es\" href=\"../es\">es</a>\n</footer>\n";
 },"useData":true});
 
-},{"hbsfy/runtime":14}],6:[function(require,module,exports){
+},{"hbsfy/runtime":15}],6:[function(require,module,exports){
 var i18n = require("./../i18n/en/en.js")
 var tpl = require('./index.hbs')
 
@@ -100,61 +100,87 @@ document.body.innerHTML = tpl({
 })
 
 },{"./../i18n/en/en.js":3,"./index.hbs":5}],7:[function(require,module,exports){
-(function (global){
-"use strict";
-/*globals Handlebars: true */
-var base = require("./handlebars/base");
+'use strict';
+
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+
+var _import = require('./handlebars/base');
+
+var base = _interopRequireWildcard(_import);
 
 // Each of these augment the Handlebars object. No need to setup here.
 // (This is done to easily share code between commonjs and browse envs)
-var SafeString = require("./handlebars/safe-string")["default"];
-var Exception = require("./handlebars/exception")["default"];
-var Utils = require("./handlebars/utils");
-var runtime = require("./handlebars/runtime");
+
+var _SafeString = require('./handlebars/safe-string');
+
+var _SafeString2 = _interopRequireWildcard(_SafeString);
+
+var _Exception = require('./handlebars/exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var _import2 = require('./handlebars/utils');
+
+var Utils = _interopRequireWildcard(_import2);
+
+var _import3 = require('./handlebars/runtime');
+
+var runtime = _interopRequireWildcard(_import3);
+
+var _noConflict = require('./handlebars/no-conflict');
+
+var _noConflict2 = _interopRequireWildcard(_noConflict);
 
 // For compatibility and usage outside of module systems, make the Handlebars object a namespace
-var create = function() {
+function create() {
   var hb = new base.HandlebarsEnvironment();
 
   Utils.extend(hb, base);
-  hb.SafeString = SafeString;
-  hb.Exception = Exception;
+  hb.SafeString = _SafeString2['default'];
+  hb.Exception = _Exception2['default'];
   hb.Utils = Utils;
   hb.escapeExpression = Utils.escapeExpression;
 
   hb.VM = runtime;
-  hb.template = function(spec) {
+  hb.template = function (spec) {
     return runtime.template(spec, hb);
   };
 
   return hb;
-};
+}
 
-var Handlebars = create();
-Handlebars.create = create;
+var inst = create();
+inst.create = create;
 
-/*jshint -W040 */
-/* istanbul ignore next */
-var root = typeof global !== 'undefined' ? global : window,
-    $Handlebars = root.Handlebars;
-/* istanbul ignore next */
-Handlebars.noConflict = function() {
-  if (root.Handlebars === Handlebars) {
-    root.Handlebars = $Handlebars;
-  }
-};
+_noConflict2['default'](inst);
 
-Handlebars['default'] = Handlebars;
+inst['default'] = inst;
 
-exports["default"] = Handlebars;
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./handlebars/base":8,"./handlebars/exception":9,"./handlebars/runtime":10,"./handlebars/safe-string":11,"./handlebars/utils":12}],8:[function(require,module,exports){
-"use strict";
-var Utils = require("./utils");
-var Exception = require("./exception")["default"];
+exports['default'] = inst;
+module.exports = exports['default'];
+},{"./handlebars/base":8,"./handlebars/exception":9,"./handlebars/no-conflict":10,"./handlebars/runtime":11,"./handlebars/safe-string":12,"./handlebars/utils":13}],8:[function(require,module,exports){
+'use strict';
 
-var VERSION = "3.0.1";
-exports.VERSION = VERSION;var COMPILER_REVISION = 6;
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+exports.HandlebarsEnvironment = HandlebarsEnvironment;
+exports.createFrame = createFrame;
+
+var _import = require('./utils');
+
+var Utils = _interopRequireWildcard(_import);
+
+var _Exception = require('./exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var VERSION = '3.0.1';
+exports.VERSION = VERSION;
+var COMPILER_REVISION = 6;
+
 exports.COMPILER_REVISION = COMPILER_REVISION;
 var REVISION_CHANGES = {
   1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
@@ -164,6 +190,7 @@ var REVISION_CHANGES = {
   5: '== 2.0.0-alpha.x',
   6: '>= 2.0.0-beta.1'
 };
+
 exports.REVISION_CHANGES = REVISION_CHANGES;
 var isArray = Utils.isArray,
     isFunction = Utils.isFunction,
@@ -177,60 +204,62 @@ function HandlebarsEnvironment(helpers, partials) {
   registerDefaultHelpers(this);
 }
 
-exports.HandlebarsEnvironment = HandlebarsEnvironment;HandlebarsEnvironment.prototype = {
+HandlebarsEnvironment.prototype = {
   constructor: HandlebarsEnvironment,
 
   logger: logger,
   log: log,
 
-  registerHelper: function(name, fn) {
+  registerHelper: function registerHelper(name, fn) {
     if (toString.call(name) === objectType) {
-      if (fn) { throw new Exception('Arg not supported with multiple helpers'); }
+      if (fn) {
+        throw new _Exception2['default']('Arg not supported with multiple helpers');
+      }
       Utils.extend(this.helpers, name);
     } else {
       this.helpers[name] = fn;
     }
   },
-  unregisterHelper: function(name) {
+  unregisterHelper: function unregisterHelper(name) {
     delete this.helpers[name];
   },
 
-  registerPartial: function(name, partial) {
+  registerPartial: function registerPartial(name, partial) {
     if (toString.call(name) === objectType) {
-      Utils.extend(this.partials,  name);
+      Utils.extend(this.partials, name);
     } else {
       if (typeof partial === 'undefined') {
-        throw new Exception('Attempting to register a partial as undefined');
+        throw new _Exception2['default']('Attempting to register a partial as undefined');
       }
       this.partials[name] = partial;
     }
   },
-  unregisterPartial: function(name) {
+  unregisterPartial: function unregisterPartial(name) {
     delete this.partials[name];
   }
 };
 
 function registerDefaultHelpers(instance) {
-  instance.registerHelper('helperMissing', function(/* [args, ]options */) {
-    if(arguments.length === 1) {
+  instance.registerHelper('helperMissing', function () {
+    if (arguments.length === 1) {
       // A missing field in a {{foo}} constuct.
       return undefined;
     } else {
       // Someone is actually trying to call something, blow up.
-      throw new Exception("Missing helper: '" + arguments[arguments.length-1].name + "'");
+      throw new _Exception2['default']('Missing helper: "' + arguments[arguments.length - 1].name + '"');
     }
   });
 
-  instance.registerHelper('blockHelperMissing', function(context, options) {
+  instance.registerHelper('blockHelperMissing', function (context, options) {
     var inverse = options.inverse,
         fn = options.fn;
 
-    if(context === true) {
+    if (context === true) {
       return fn(this);
-    } else if(context === false || context == null) {
+    } else if (context === false || context == null) {
       return inverse(this);
     } else if (isArray(context)) {
-      if(context.length > 0) {
+      if (context.length > 0) {
         if (options.ids) {
           options.ids = [options.name];
         }
@@ -243,102 +272,111 @@ function registerDefaultHelpers(instance) {
       if (options.data && options.ids) {
         var data = createFrame(options.data);
         data.contextPath = Utils.appendContextPath(options.data.contextPath, options.name);
-        options = {data: data};
+        options = { data: data };
       }
 
       return fn(context, options);
     }
   });
 
-  instance.registerHelper('each', function(context, options) {
+  instance.registerHelper('each', function (context, options) {
     if (!options) {
-      throw new Exception('Must pass iterator to #each');
+      throw new _Exception2['default']('Must pass iterator to #each');
     }
 
-    var fn = options.fn, inverse = options.inverse;
-    var i = 0, ret = "", data;
+    var fn = options.fn,
+        inverse = options.inverse,
+        i = 0,
+        ret = '',
+        data = undefined,
+        contextPath = undefined;
 
-    var contextPath;
     if (options.data && options.ids) {
       contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
     }
 
-    if (isFunction(context)) { context = context.call(this); }
+    if (isFunction(context)) {
+      context = context.call(this);
+    }
 
     if (options.data) {
       data = createFrame(options.data);
     }
 
-    function execIteration(key, i, last) {
+    function execIteration(field, index, last) {
       if (data) {
-        data.key = key;
-        data.index = i;
-        data.first = i === 0;
-        data.last  = !!last;
+        data.key = field;
+        data.index = index;
+        data.first = index === 0;
+        data.last = !!last;
 
         if (contextPath) {
-          data.contextPath = contextPath + key;
+          data.contextPath = contextPath + field;
         }
       }
 
-      ret = ret + fn(context[key], {
+      ret = ret + fn(context[field], {
         data: data,
-        blockParams: Utils.blockParams([context[key], key], [contextPath + key, null])
+        blockParams: Utils.blockParams([context[field], field], [contextPath + field, null])
       });
     }
 
-    if(context && typeof context === 'object') {
+    if (context && typeof context === 'object') {
       if (isArray(context)) {
-        for(var j = context.length; i<j; i++) {
-          execIteration(i, i, i === context.length-1);
+        for (var j = context.length; i < j; i++) {
+          execIteration(i, i, i === context.length - 1);
         }
       } else {
-        var priorKey;
+        var priorKey = undefined;
 
-        for(var key in context) {
-          if(context.hasOwnProperty(key)) {
+        for (var key in context) {
+          if (context.hasOwnProperty(key)) {
             // We're running the iterations one step out of sync so we can detect
             // the last iteration without have to scan the object twice and create
-            // an itermediate keys array. 
+            // an itermediate keys array.
             if (priorKey) {
-              execIteration(priorKey, i-1);
+              execIteration(priorKey, i - 1);
             }
             priorKey = key;
             i++;
           }
         }
         if (priorKey) {
-          execIteration(priorKey, i-1, true);
+          execIteration(priorKey, i - 1, true);
         }
       }
     }
 
-    if(i === 0){
+    if (i === 0) {
       ret = inverse(this);
     }
 
     return ret;
   });
 
-  instance.registerHelper('if', function(conditional, options) {
-    if (isFunction(conditional)) { conditional = conditional.call(this); }
+  instance.registerHelper('if', function (conditional, options) {
+    if (isFunction(conditional)) {
+      conditional = conditional.call(this);
+    }
 
     // Default behavior is to render the positive path if the value is truthy and not empty.
     // The `includeZero` option may be set to treat the condtional as purely not empty based on the
     // behavior of isEmpty. Effectively this determines if 0 is handled by the positive path or negative.
-    if ((!options.hash.includeZero && !conditional) || Utils.isEmpty(conditional)) {
+    if (!options.hash.includeZero && !conditional || Utils.isEmpty(conditional)) {
       return options.inverse(this);
     } else {
       return options.fn(this);
     }
   });
 
-  instance.registerHelper('unless', function(conditional, options) {
-    return instance.helpers['if'].call(this, conditional, {fn: options.inverse, inverse: options.fn, hash: options.hash});
+  instance.registerHelper('unless', function (conditional, options) {
+    return instance.helpers['if'].call(this, conditional, { fn: options.inverse, inverse: options.fn, hash: options.hash });
   });
 
-  instance.registerHelper('with', function(context, options) {
-    if (isFunction(context)) { context = context.call(this); }
+  instance.registerHelper('with', function (context, options) {
+    if (isFunction(context)) {
+      context = context.call(this);
+    }
 
     var fn = options.fn;
 
@@ -346,7 +384,7 @@ function registerDefaultHelpers(instance) {
       if (options.data && options.ids) {
         var data = createFrame(options.data);
         data.contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]);
-        options = {data:data};
+        options = { data: data };
       }
 
       return fn(context, options);
@@ -355,12 +393,12 @@ function registerDefaultHelpers(instance) {
     }
   });
 
-  instance.registerHelper('log', function(message, options) {
+  instance.registerHelper('log', function (message, options) {
     var level = options.data && options.data.level != null ? parseInt(options.data.level, 10) : 1;
     instance.log(level, message);
   });
 
-  instance.registerHelper('lookup', function(obj, field) {
+  instance.registerHelper('lookup', function (obj, field) {
     return obj && obj[field];
   });
 }
@@ -376,31 +414,37 @@ var logger = {
   level: 1,
 
   // Can be overridden in the host environment
-  log: function(level, message) {
+  log: function log(level, message) {
     if (typeof console !== 'undefined' && logger.level <= level) {
       var method = logger.methodMap[level];
-      (console[method] || console.log).call(console, message);
+      (console[method] || console.log).call(console, message); // eslint-disable-line no-console
     }
   }
 };
+
 exports.logger = logger;
 var log = logger.log;
+
 exports.log = log;
-var createFrame = function(object) {
+
+function createFrame(object) {
   var frame = Utils.extend({}, object);
   frame._parent = object;
   return frame;
-};
-exports.createFrame = createFrame;
-},{"./exception":9,"./utils":12}],9:[function(require,module,exports){
-"use strict";
+}
+
+/* [args, ]options */
+},{"./exception":9,"./utils":13}],9:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
 
 var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
 
 function Exception(message, node) {
   var loc = node && node.loc,
-      line,
-      column;
+      line = undefined,
+      column = undefined;
   if (loc) {
     line = loc.start.line;
     column = loc.start.column;
@@ -415,6 +459,10 @@ function Exception(message, node) {
     this[errorProps[idx]] = tmp[errorProps[idx]];
   }
 
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, Exception);
+  }
+
   if (loc) {
     this.lineNumber = line;
     this.column = column;
@@ -423,49 +471,85 @@ function Exception(message, node) {
 
 Exception.prototype = new Error();
 
-exports["default"] = Exception;
+exports['default'] = Exception;
+module.exports = exports['default'];
 },{}],10:[function(require,module,exports){
-"use strict";
-var Utils = require("./utils");
-var Exception = require("./exception")["default"];
-var COMPILER_REVISION = require("./base").COMPILER_REVISION;
-var REVISION_CHANGES = require("./base").REVISION_CHANGES;
-var createFrame = require("./base").createFrame;
+(function (global){
+'use strict';
+
+exports.__esModule = true;
+/*global window */
+
+exports['default'] = function (Handlebars) {
+  /* istanbul ignore next */
+  var root = typeof global !== 'undefined' ? global : window,
+      $Handlebars = root.Handlebars;
+  /* istanbul ignore next */
+  Handlebars.noConflict = function () {
+    if (root.Handlebars === Handlebars) {
+      root.Handlebars = $Handlebars;
+    }
+  };
+};
+
+module.exports = exports['default'];
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],11:[function(require,module,exports){
+'use strict';
+
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+exports.checkRevision = checkRevision;
+
+// TODO: Remove this line and break up compilePartial
+
+exports.template = template;
+exports.wrapProgram = wrapProgram;
+exports.resolvePartial = resolvePartial;
+exports.invokePartial = invokePartial;
+exports.noop = noop;
+
+var _import = require('./utils');
+
+var Utils = _interopRequireWildcard(_import);
+
+var _Exception = require('./exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var _COMPILER_REVISION$REVISION_CHANGES$createFrame = require('./base');
 
 function checkRevision(compilerInfo) {
   var compilerRevision = compilerInfo && compilerInfo[0] || 1,
-      currentRevision = COMPILER_REVISION;
+      currentRevision = _COMPILER_REVISION$REVISION_CHANGES$createFrame.COMPILER_REVISION;
 
   if (compilerRevision !== currentRevision) {
     if (compilerRevision < currentRevision) {
-      var runtimeVersions = REVISION_CHANGES[currentRevision],
-          compilerVersions = REVISION_CHANGES[compilerRevision];
-      throw new Exception("Template was precompiled with an older version of Handlebars than the current runtime. "+
-            "Please update your precompiler to a newer version ("+runtimeVersions+") or downgrade your runtime to an older version ("+compilerVersions+").");
+      var runtimeVersions = _COMPILER_REVISION$REVISION_CHANGES$createFrame.REVISION_CHANGES[currentRevision],
+          compilerVersions = _COMPILER_REVISION$REVISION_CHANGES$createFrame.REVISION_CHANGES[compilerRevision];
+      throw new _Exception2['default']('Template was precompiled with an older version of Handlebars than the current runtime. ' + 'Please update your precompiler to a newer version (' + runtimeVersions + ') or downgrade your runtime to an older version (' + compilerVersions + ').');
     } else {
       // Use the embedded version info since the runtime doesn't know about this revision yet
-      throw new Exception("Template was precompiled with a newer version of Handlebars than the current runtime. "+
-            "Please update your runtime to a newer version ("+compilerInfo[1]+").");
+      throw new _Exception2['default']('Template was precompiled with a newer version of Handlebars than the current runtime. ' + 'Please update your runtime to a newer version (' + compilerInfo[1] + ').');
     }
   }
 }
 
-exports.checkRevision = checkRevision;// TODO: Remove this line and break up compilePartial
-
 function template(templateSpec, env) {
   /* istanbul ignore next */
   if (!env) {
-    throw new Exception("No environment passed to template");
+    throw new _Exception2['default']('No environment passed to template');
   }
   if (!templateSpec || !templateSpec.main) {
-    throw new Exception('Unknown template object: ' + typeof templateSpec);
+    throw new _Exception2['default']('Unknown template object: ' + typeof templateSpec);
   }
 
   // Note: Using env.VM references rather than local var references throughout this section to allow
   // for external users to override these as psuedo-supported APIs.
   env.VM.checkRevision(templateSpec.compiler);
 
-  var invokePartialWrapper = function(partial, context, options) {
+  function invokePartialWrapper(partial, context, options) {
     if (options.hash) {
       context = Utils.extend({}, context, options.hash);
     }
@@ -491,19 +575,19 @@ function template(templateSpec, env) {
       }
       return result;
     } else {
-      throw new Exception("The partial " + options.name + " could not be compiled when running in runtime-only mode");
+      throw new _Exception2['default']('The partial ' + options.name + ' could not be compiled when running in runtime-only mode');
     }
-  };
+  }
 
   // Just add water
   var container = {
-    strict: function(obj, name) {
+    strict: function strict(obj, name) {
       if (!(name in obj)) {
-        throw new Exception('"' + name + '" not defined in ' + obj);
+        throw new _Exception2['default']('"' + name + '" not defined in ' + obj);
       }
       return obj[name];
     },
-    lookup: function(depths, name) {
+    lookup: function lookup(depths, name) {
       var len = depths.length;
       for (var i = 0; i < len; i++) {
         if (depths[i] && depths[i][name] != null) {
@@ -511,68 +595,69 @@ function template(templateSpec, env) {
         }
       }
     },
-    lambda: function(current, context) {
+    lambda: function lambda(current, context) {
       return typeof current === 'function' ? current.call(context) : current;
     },
 
     escapeExpression: Utils.escapeExpression,
     invokePartial: invokePartialWrapper,
 
-    fn: function(i) {
+    fn: function fn(i) {
       return templateSpec[i];
     },
 
     programs: [],
-    program: function(i, data, declaredBlockParams, blockParams, depths) {
+    program: function program(i, data, declaredBlockParams, blockParams, depths) {
       var programWrapper = this.programs[i],
           fn = this.fn(i);
       if (data || depths || blockParams || declaredBlockParams) {
-        programWrapper = program(this, i, fn, data, declaredBlockParams, blockParams, depths);
+        programWrapper = wrapProgram(this, i, fn, data, declaredBlockParams, blockParams, depths);
       } else if (!programWrapper) {
-        programWrapper = this.programs[i] = program(this, i, fn);
+        programWrapper = this.programs[i] = wrapProgram(this, i, fn);
       }
       return programWrapper;
     },
 
-    data: function(data, depth) {
-      while (data && depth--) {
-        data = data._parent;
+    data: function data(value, depth) {
+      while (value && depth--) {
+        value = value._parent;
       }
-      return data;
+      return value;
     },
-    merge: function(param, common) {
-      var ret = param || common;
+    merge: function merge(param, common) {
+      var obj = param || common;
 
-      if (param && common && (param !== common)) {
-        ret = Utils.extend({}, common, param);
+      if (param && common && param !== common) {
+        obj = Utils.extend({}, common, param);
       }
 
-      return ret;
+      return obj;
     },
 
     noop: env.VM.noop,
     compilerInfo: templateSpec.compiler
   };
 
-  var ret = function(context, options) {
-    options = options || {};
+  function ret(context) {
+    var options = arguments[1] === undefined ? {} : arguments[1];
+
     var data = options.data;
 
     ret._setup(options);
     if (!options.partial && templateSpec.useData) {
       data = initData(context, data);
     }
-    var depths,
+    var depths = undefined,
         blockParams = templateSpec.useBlockParams ? [] : undefined;
     if (templateSpec.useDepths) {
       depths = options.depths ? [context].concat(options.depths) : [context];
     }
 
     return templateSpec.main.call(container, context, container.helpers, container.partials, data, blockParams, depths);
-  };
+  }
   ret.isTop = true;
 
-  ret._setup = function(options) {
+  ret._setup = function (options) {
     if (!options.partial) {
       container.helpers = container.merge(options.helpers, env.helpers);
 
@@ -585,37 +670,32 @@ function template(templateSpec, env) {
     }
   };
 
-  ret._child = function(i, data, blockParams, depths) {
+  ret._child = function (i, data, blockParams, depths) {
     if (templateSpec.useBlockParams && !blockParams) {
-      throw new Exception('must pass block params');
+      throw new _Exception2['default']('must pass block params');
     }
     if (templateSpec.useDepths && !depths) {
-      throw new Exception('must pass parent depths');
+      throw new _Exception2['default']('must pass parent depths');
     }
 
-    return program(container, i, templateSpec[i], data, 0, blockParams, depths);
+    return wrapProgram(container, i, templateSpec[i], data, 0, blockParams, depths);
   };
   return ret;
 }
 
-exports.template = template;function program(container, i, fn, data, declaredBlockParams, blockParams, depths) {
-  var prog = function(context, options) {
-    options = options || {};
+function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, depths) {
+  function prog(context) {
+    var options = arguments[1] === undefined ? {} : arguments[1];
 
-    return fn.call(container,
-        context,
-        container.helpers, container.partials,
-        options.data || data,
-        blockParams && [options.blockParams].concat(blockParams),
-        depths && [context].concat(depths));
-  };
+    return fn.call(container, context, container.helpers, container.partials, options.data || data, blockParams && [options.blockParams].concat(blockParams), depths && [context].concat(depths));
+  }
   prog.program = i;
   prog.depth = depths ? depths.length : 0;
   prog.blockParams = declaredBlockParams || 0;
   return prog;
 }
 
-exports.program = program;function resolvePartial(partial, context, options) {
+function resolvePartial(partial, context, options) {
   if (!partial) {
     partial = options.partials[options.name];
   } else if (!partial.call && !options.name) {
@@ -626,51 +706,65 @@ exports.program = program;function resolvePartial(partial, context, options) {
   return partial;
 }
 
-exports.resolvePartial = resolvePartial;function invokePartial(partial, context, options) {
+function invokePartial(partial, context, options) {
   options.partial = true;
 
-  if(partial === undefined) {
-    throw new Exception("The partial " + options.name + " could not be found");
-  } else if(partial instanceof Function) {
+  if (partial === undefined) {
+    throw new _Exception2['default']('The partial ' + options.name + ' could not be found');
+  } else if (partial instanceof Function) {
     return partial(context, options);
   }
 }
 
-exports.invokePartial = invokePartial;function noop() { return ""; }
+function noop() {
+  return '';
+}
 
-exports.noop = noop;function initData(context, data) {
+function initData(context, data) {
   if (!data || !('root' in data)) {
-    data = data ? createFrame(data) : {};
+    data = data ? _COMPILER_REVISION$REVISION_CHANGES$createFrame.createFrame(data) : {};
     data.root = context;
   }
   return data;
 }
-},{"./base":8,"./exception":9,"./utils":12}],11:[function(require,module,exports){
-"use strict";
+},{"./base":8,"./exception":9,"./utils":13}],12:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
 // Build out our basic SafeString type
 function SafeString(string) {
   this.string = string;
 }
 
-SafeString.prototype.toString = SafeString.prototype.toHTML = function() {
-  return "" + this.string;
+SafeString.prototype.toString = SafeString.prototype.toHTML = function () {
+  return '' + this.string;
 };
 
-exports["default"] = SafeString;
-},{}],12:[function(require,module,exports){
-"use strict";
-/*jshint -W004 */
+exports['default'] = SafeString;
+module.exports = exports['default'];
+},{}],13:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
+exports.extend = extend;
+
+// Older IE versions do not directly support indexOf so we must implement our own, sadly.
+exports.indexOf = indexOf;
+exports.escapeExpression = escapeExpression;
+exports.isEmpty = isEmpty;
+exports.blockParams = blockParams;
+exports.appendContextPath = appendContextPath;
 var escape = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&#x27;",
-  "`": "&#x60;"
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  '\'': '&#x27;',
+  '`': '&#x60;'
 };
 
-var badChars = /[&<>"'`]/g;
-var possible = /[&<>"'`]/;
+var badChars = /[&<>"'`]/g,
+    possible = /[&<>"'`]/;
 
 function escapeChar(chr) {
   return escape[chr];
@@ -688,28 +782,31 @@ function extend(obj /* , ...source */) {
   return obj;
 }
 
-exports.extend = extend;var toString = Object.prototype.toString;
+var toString = Object.prototype.toString;
+
 exports.toString = toString;
 // Sourced from lodash
 // https://github.com/bestiejs/lodash/blob/master/LICENSE.txt
-var isFunction = function(value) {
+/*eslint-disable func-style, no-var */
+var isFunction = function isFunction(value) {
   return typeof value === 'function';
 };
 // fallback for older versions of Chrome and Safari
 /* istanbul ignore next */
 if (isFunction(/x/)) {
-  isFunction = function(value) {
+  exports.isFunction = isFunction = function (value) {
     return typeof value === 'function' && toString.call(value) === '[object Function]';
   };
 }
 var isFunction;
 exports.isFunction = isFunction;
+/*eslint-enable func-style, no-var */
+
 /* istanbul ignore next */
-var isArray = Array.isArray || function(value) {
-  return (value && typeof value === 'object') ? toString.call(value) === '[object Array]' : false;
-};
-exports.isArray = isArray;
-// Older IE versions do not directly support indexOf so we must implement our own, sadly.
+var isArray = Array.isArray || function (value) {
+  return value && typeof value === 'object' ? toString.call(value) === '[object Array]' : false;
+};exports.isArray = isArray;
+
 function indexOf(array, value) {
   for (var i = 0, len = array.length; i < len; i++) {
     if (array[i] === value) {
@@ -719,7 +816,6 @@ function indexOf(array, value) {
   return -1;
 }
 
-exports.indexOf = indexOf;
 function escapeExpression(string) {
   if (typeof string !== 'string') {
     // don't escape SafeStrings, since they're already safe
@@ -737,11 +833,13 @@ function escapeExpression(string) {
     string = '' + string;
   }
 
-  if (!possible.test(string)) { return string; }
+  if (!possible.test(string)) {
+    return string;
+  }
   return string.replace(badChars, escapeChar);
 }
 
-exports.escapeExpression = escapeExpression;function isEmpty(value) {
+function isEmpty(value) {
   if (!value && value !== 0) {
     return true;
   } else if (isArray(value) && value.length === 0) {
@@ -751,25 +849,23 @@ exports.escapeExpression = escapeExpression;function isEmpty(value) {
   }
 }
 
-exports.isEmpty = isEmpty;function blockParams(params, ids) {
+function blockParams(params, ids) {
   params.path = ids;
   return params;
 }
 
-exports.blockParams = blockParams;function appendContextPath(contextPath, id) {
+function appendContextPath(contextPath, id) {
   return (contextPath ? contextPath + '.' : '') + id;
 }
-
-exports.appendContextPath = appendContextPath;
-},{}],13:[function(require,module,exports){
+},{}],14:[function(require,module,exports){
 // Create a simple path alias to allow browserify to resolve
 // the runtime on a supported path.
 module.exports = require('./dist/cjs/handlebars.runtime')['default'];
 
-},{"./dist/cjs/handlebars.runtime":7}],14:[function(require,module,exports){
+},{"./dist/cjs/handlebars.runtime":7}],15:[function(require,module,exports){
 module.exports = require("handlebars/runtime")["default"];
 
-},{"handlebars/runtime":13}],15:[function(require,module,exports){
+},{"handlebars/runtime":14}],16:[function(require,module,exports){
 /**
  * @preserve jed.js https://github.com/SlexAxton/Jed
  */
@@ -1793,9 +1889,9 @@ return parser;
 
 })(this);
 
-},{}],16:[function(require,module,exports){
+},{}],17:[function(require,module,exports){
 //! moment.js
-//! version : 2.10.2
+//! version : 2.10.3
 //! authors : Tim Wood, Iskren Chernev, Moment.js contributors
 //! license : MIT
 //! momentjs.com
@@ -1818,28 +1914,12 @@ return parser;
         hookCallback = callback;
     }
 
-    function defaultParsingFlags() {
-        // We need to deep clone this object.
-        return {
-            empty           : false,
-            unusedTokens    : [],
-            unusedInput     : [],
-            overflow        : -2,
-            charsLeftOver   : 0,
-            nullInput       : false,
-            invalidMonth    : null,
-            invalidFormat   : false,
-            userInvalidated : false,
-            iso             : false
-        };
-    }
-
     function isArray(input) {
         return Object.prototype.toString.call(input) === '[object Array]';
     }
 
     function isDate(input) {
-        return Object.prototype.toString.call(input) === '[object Date]' || input instanceof Date;
+        return input instanceof Date || Object.prototype.toString.call(input) === '[object Date]';
     }
 
     function map(arr, fn) {
@@ -1876,21 +1956,45 @@ return parser;
         return createLocalOrUTC(input, format, locale, strict, true).utc();
     }
 
+    function defaultParsingFlags() {
+        // We need to deep clone this object.
+        return {
+            empty           : false,
+            unusedTokens    : [],
+            unusedInput     : [],
+            overflow        : -2,
+            charsLeftOver   : 0,
+            nullInput       : false,
+            invalidMonth    : null,
+            invalidFormat   : false,
+            userInvalidated : false,
+            iso             : false
+        };
+    }
+
+    function getParsingFlags(m) {
+        if (m._pf == null) {
+            m._pf = defaultParsingFlags();
+        }
+        return m._pf;
+    }
+
     function valid__isValid(m) {
         if (m._isValid == null) {
+            var flags = getParsingFlags(m);
             m._isValid = !isNaN(m._d.getTime()) &&
-                m._pf.overflow < 0 &&
-                !m._pf.empty &&
-                !m._pf.invalidMonth &&
-                !m._pf.nullInput &&
-                !m._pf.invalidFormat &&
-                !m._pf.userInvalidated;
+                flags.overflow < 0 &&
+                !flags.empty &&
+                !flags.invalidMonth &&
+                !flags.nullInput &&
+                !flags.invalidFormat &&
+                !flags.userInvalidated;
 
             if (m._strict) {
                 m._isValid = m._isValid &&
-                    m._pf.charsLeftOver === 0 &&
-                    m._pf.unusedTokens.length === 0 &&
-                    m._pf.bigHour === undefined;
+                    flags.charsLeftOver === 0 &&
+                    flags.unusedTokens.length === 0 &&
+                    flags.bigHour === undefined;
             }
         }
         return m._isValid;
@@ -1899,10 +2003,10 @@ return parser;
     function valid__createInvalid (flags) {
         var m = create_utc__createUTC(NaN);
         if (flags != null) {
-            extend(m._pf, flags);
+            extend(getParsingFlags(m), flags);
         }
         else {
-            m._pf.userInvalidated = true;
+            getParsingFlags(m).userInvalidated = true;
         }
 
         return m;
@@ -1938,7 +2042,7 @@ return parser;
             to._offset = from._offset;
         }
         if (typeof from._pf !== 'undefined') {
-            to._pf = from._pf;
+            to._pf = getParsingFlags(from);
         }
         if (typeof from._locale !== 'undefined') {
             to._locale = from._locale;
@@ -1973,7 +2077,7 @@ return parser;
     }
 
     function isMoment (obj) {
-        return obj instanceof Moment || (obj != null && hasOwnProp(obj, '_isAMomentObject'));
+        return obj instanceof Moment || (obj != null && obj._isAMomentObject != null);
     }
 
     function toInt(argumentForCoercion) {
@@ -2411,7 +2515,7 @@ return parser;
         if (month != null) {
             array[MONTH] = month;
         } else {
-            config._pf.invalidMonth = input;
+            getParsingFlags(config).invalidMonth = input;
         }
     });
 
@@ -2495,7 +2599,7 @@ return parser;
         var overflow;
         var a = m._a;
 
-        if (a && m._pf.overflow === -2) {
+        if (a && getParsingFlags(m).overflow === -2) {
             overflow =
                 a[MONTH]       < 0 || a[MONTH]       > 11  ? MONTH :
                 a[DATE]        < 1 || a[DATE]        > daysInMonth(a[YEAR], a[MONTH]) ? DATE :
@@ -2505,11 +2609,11 @@ return parser;
                 a[MILLISECOND] < 0 || a[MILLISECOND] > 999 ? MILLISECOND :
                 -1;
 
-            if (m._pf._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
+            if (getParsingFlags(m)._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
                 overflow = DATE;
             }
 
-            m._pf.overflow = overflow;
+            getParsingFlags(m).overflow = overflow;
         }
 
         return m;
@@ -2522,10 +2626,12 @@ return parser;
     }
 
     function deprecate(msg, fn) {
-        var firstTime = true;
+        var firstTime = true,
+            msgWithStack = msg + '\n' + (new Error()).stack;
+
         return extend(function () {
             if (firstTime) {
-                warn(msg);
+                warn(msgWithStack);
                 firstTime = false;
             }
             return fn.apply(this, arguments);
@@ -2570,7 +2676,7 @@ return parser;
             match = from_string__isoRegex.exec(string);
 
         if (match) {
-            config._pf.iso = true;
+            getParsingFlags(config).iso = true;
             for (i = 0, l = isoDates.length; i < l; i++) {
                 if (isoDates[i][1].exec(string)) {
                     // match[5] should be 'T' or undefined
@@ -2850,7 +2956,7 @@ return parser;
             yearToUse = defaults(config._a[YEAR], currentDate[YEAR]);
 
             if (config._dayOfYear > daysInYear(yearToUse)) {
-                config._pf._overflowDayOfYear = true;
+                getParsingFlags(config)._overflowDayOfYear = true;
             }
 
             date = createUTCDate(yearToUse, 0, config._dayOfYear);
@@ -2946,7 +3052,7 @@ return parser;
         }
 
         config._a = [];
-        config._pf.empty = true;
+        getParsingFlags(config).empty = true;
 
         // This array is used to make a Date, either with `new Date` or `Date.UTC`
         var string = '' + config._i,
@@ -2962,7 +3068,7 @@ return parser;
             if (parsedInput) {
                 skipped = string.substr(0, string.indexOf(parsedInput));
                 if (skipped.length > 0) {
-                    config._pf.unusedInput.push(skipped);
+                    getParsingFlags(config).unusedInput.push(skipped);
                 }
                 string = string.slice(string.indexOf(parsedInput) + parsedInput.length);
                 totalParsedInputLength += parsedInput.length;
@@ -2970,27 +3076,29 @@ return parser;
             // don't parse if it's not a known token
             if (formatTokenFunctions[token]) {
                 if (parsedInput) {
-                    config._pf.empty = false;
+                    getParsingFlags(config).empty = false;
                 }
                 else {
-                    config._pf.unusedTokens.push(token);
+                    getParsingFlags(config).unusedTokens.push(token);
                 }
                 addTimeToArrayFromToken(token, parsedInput, config);
             }
             else if (config._strict && !parsedInput) {
-                config._pf.unusedTokens.push(token);
+                getParsingFlags(config).unusedTokens.push(token);
             }
         }
 
         // add remaining unparsed input length to the string
-        config._pf.charsLeftOver = stringLength - totalParsedInputLength;
+        getParsingFlags(config).charsLeftOver = stringLength - totalParsedInputLength;
         if (string.length > 0) {
-            config._pf.unusedInput.push(string);
+            getParsingFlags(config).unusedInput.push(string);
         }
 
         // clear _12h flag if hour is <= 12
-        if (config._pf.bigHour === true && config._a[HOUR] <= 12) {
-            config._pf.bigHour = undefined;
+        if (getParsingFlags(config).bigHour === true &&
+                config._a[HOUR] <= 12 &&
+                config._a[HOUR] > 0) {
+            getParsingFlags(config).bigHour = undefined;
         }
         // handle meridiem
         config._a[HOUR] = meridiemFixWrap(config._locale, config._a[HOUR], config._meridiem);
@@ -3034,7 +3142,7 @@ return parser;
             currentScore;
 
         if (config._f.length === 0) {
-            config._pf.invalidFormat = true;
+            getParsingFlags(config).invalidFormat = true;
             config._d = new Date(NaN);
             return;
         }
@@ -3045,7 +3153,6 @@ return parser;
             if (config._useUTC != null) {
                 tempConfig._useUTC = config._useUTC;
             }
-            tempConfig._pf = defaultParsingFlags();
             tempConfig._f = config._f[i];
             configFromStringAndFormat(tempConfig);
 
@@ -3054,12 +3161,12 @@ return parser;
             }
 
             // if there is any input that was not parsed add a penalty for that format
-            currentScore += tempConfig._pf.charsLeftOver;
+            currentScore += getParsingFlags(tempConfig).charsLeftOver;
 
             //or tokens
-            currentScore += tempConfig._pf.unusedTokens.length * 10;
+            currentScore += getParsingFlags(tempConfig).unusedTokens.length * 10;
 
-            tempConfig._pf.score = currentScore;
+            getParsingFlags(tempConfig).score = currentScore;
 
             if (scoreToBeat == null || currentScore < scoreToBeat) {
                 scoreToBeat = currentScore;
@@ -3102,6 +3209,8 @@ return parser;
             configFromStringAndArray(config);
         } else if (format) {
             configFromStringAndFormat(config);
+        } else if (isDate(input)) {
+            config._d = input;
         } else {
             configFromInput(config);
         }
@@ -3154,7 +3263,6 @@ return parser;
         c._i = input;
         c._f = format;
         c._strict = strict;
-        c._pf = defaultParsingFlags();
 
         return createFromConfig(c);
     }
@@ -3728,11 +3836,25 @@ return parser;
     }
 
     function from (time, withoutSuffix) {
+        if (!this.isValid()) {
+            return this.localeData().invalidDate();
+        }
         return create__createDuration({to: this, from: time}).locale(this.locale()).humanize(!withoutSuffix);
     }
 
     function fromNow (withoutSuffix) {
         return this.from(local__createLocal(), withoutSuffix);
+    }
+
+    function to (time, withoutSuffix) {
+        if (!this.isValid()) {
+            return this.localeData().invalidDate();
+        }
+        return create__createDuration({from: this, to: time}).locale(this.locale()).humanize(!withoutSuffix);
+    }
+
+    function toNow (withoutSuffix) {
+        return this.to(local__createLocal(), withoutSuffix);
     }
 
     function locale (key) {
@@ -3837,11 +3959,11 @@ return parser;
     }
 
     function parsingFlags () {
-        return extend({}, this._pf);
+        return extend({}, getParsingFlags(this));
     }
 
     function invalidAt () {
-        return this._pf.overflow;
+        return getParsingFlags(this).overflow;
     }
 
     addFormatToken(0, ['gg', 2], 0, function () {
@@ -3992,7 +4114,7 @@ return parser;
         if (weekday != null) {
             week.d = weekday;
         } else {
-            config._pf.invalidWeekday = input;
+            getParsingFlags(config).invalidWeekday = input;
         }
     });
 
@@ -4117,7 +4239,7 @@ return parser;
     });
     addParseToken(['h', 'hh'], function (input, array, config) {
         array[HOUR] = toInt(input);
-        config._pf.bigHour = true;
+        getParsingFlags(config).bigHour = true;
     });
 
     // LOCALES
@@ -4234,6 +4356,8 @@ return parser;
     momentPrototype__proto.format       = format;
     momentPrototype__proto.from         = from;
     momentPrototype__proto.fromNow      = fromNow;
+    momentPrototype__proto.to           = to;
+    momentPrototype__proto.toNow        = toNow;
     momentPrototype__proto.get          = getSet;
     momentPrototype__proto.invalidAt    = invalidAt;
     momentPrototype__proto.isAfter      = isAfter;
@@ -4422,7 +4546,7 @@ return parser;
         }
         // Lenient ordinal parsing accepts just a number in addition to
         // number + (possibly) stuff coming from _ordinalParseLenient.
-        this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + /\d{1,2}/.source);
+        this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + (/\d{1,2}/).source);
     }
 
     var prototype__proto = Locale.prototype;
@@ -4639,13 +4763,13 @@ return parser;
             // handle milliseconds separately because of floating point math errors (issue #1867)
             days = this._days + Math.round(yearsToDays(this._months / 12));
             switch (units) {
-                case 'week'   : return days / 7            + milliseconds / 6048e5;
-                case 'day'    : return days                + milliseconds / 864e5;
-                case 'hour'   : return days * 24           + milliseconds / 36e5;
-                case 'minute' : return days * 24 * 60      + milliseconds / 6e4;
-                case 'second' : return days * 24 * 60 * 60 + milliseconds / 1000;
+                case 'week'   : return days / 7     + milliseconds / 6048e5;
+                case 'day'    : return days         + milliseconds / 864e5;
+                case 'hour'   : return days * 24    + milliseconds / 36e5;
+                case 'minute' : return days * 1440  + milliseconds / 6e4;
+                case 'second' : return days * 86400 + milliseconds / 1000;
                 // Math.floor prevents floating point math errors here
-                case 'millisecond': return Math.floor(days * 24 * 60 * 60 * 1000) + milliseconds;
+                case 'millisecond': return Math.floor(days * 864e5) + milliseconds;
                 default: throw new Error('Unknown unit ' + units);
             }
         }
@@ -4846,7 +4970,7 @@ return parser;
     // Side effect imports
 
 
-    utils_hooks__hooks.version = '2.10.2';
+    utils_hooks__hooks.version = '2.10.3';
 
     setHookCallback(local__createLocal);
 

--- a/dist/es/bundle.js
+++ b/dist/es/bundle.js
@@ -8,7 +8,7 @@ Handlebars.registerHelper('ngettext', function (one, other, count) {
 
 require('./login')
 
-},{"./i18n/es/es.js":3,"./login":6,"handlebars/runtime":13}],2:[function(require,module,exports){
+},{"./i18n/es/es.js":3,"./login":6,"handlebars/runtime":14}],2:[function(require,module,exports){
 module.exports={
   "frontend": {
     "" : {
@@ -28,7 +28,8 @@ module.exports={
     "There is 1 new alert": ["Hay 1 nueva alerta", "Hay %s nuevas alertas"],
     "There is %d new warning": ["Hay 1 nuevo aviso", "Hay %d nuevos avisos"],
     "There will be 1h of scheduled maintenance on %s": ["Habrá 1h de mantenimiento programado el %s"],
-    "Please enter your email and password to log in": ["Por favor, introduzca su correo electrónico y contraseña para entrar"]
+    "Please enter your email and password to log in": ["Por favor, introduzca su correo electrónico y contraseña para entrar"],
+    "Your email address": ["Su dirección de correo electrónico"]
   }
 }
 
@@ -43,7 +44,7 @@ var i18n = require('../i18n.js')
 module.exports = i18n(require('./dict.json'))
 module.exports.moment = moment
 module.exports.locale = 'es'
-},{"../i18n.js":4,"./dict.json":2,"moment":17,"moment/locale/es":16}],4:[function(require,module,exports){
+},{"../i18n.js":4,"./dict.json":2,"moment":18,"moment/locale/es":17}],4:[function(require,module,exports){
 /*
 # i18n.js - used at run-time & build-time for getext style string translation
 */
@@ -57,7 +58,7 @@ module.exports = function (dict) {
   })
 }
 
-},{"jed":15}],5:[function(require,module,exports){
+},{"jed":16}],5:[function(require,module,exports){
 // hbsfy compiled Handlebars template
 var HandlebarsCompiler = require('hbsfy/runtime');
 module.exports = HandlebarsCompiler.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
@@ -79,12 +80,12 @@ module.exports = HandlebarsCompiler.template({"compiler":[6,">= 2.0.0-beta.1"],"
     + alias3(((helper = (helper = helpers.locale || (depth0 != null ? depth0.locale : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"locale","hash":{},"data":data}) : helper)))
     + "\"></div>\n    </div>\n\n    <div class=\"col-sm-6\">\n      <form class=\"login__form form\">\n        <h3 data-i18n=\"login/index.hbs\">Iniciar sesión</h3>\n        <p class=\"login__lead\" data-i18n=\"login/index.hbs\">Por favor, introduzca su correo electrónico y contraseña para entrar</p>\n        <div class=\"form-group\">\n            <label for=\"username\" data-i18n=\"login/index.hbs\">Correo electrónico</label>\n            <input type=\"text\" class=\"form-control\" name=\"username\" autocorrect=\"off\" autocapitalize=\"off\" value=\""
     + ((stack1 = this.lambda(((stack1 = (depth0 != null ? depth0.prefill : depth0)) != null ? stack1.username : stack1), depth0)) != null ? stack1 : "")
-    + "\">\n        </div>\n        <div class=\"form-group\">\n            <label for=\"password\" data-i18n=\"login/index.hbs\">Contraseña</label>\n            <input type=\"password\" class=\"form-control\" name=\"password\">\n        </div>\n        <div class=\"checkbox\">\n            <label>\n                <input type=\"checkbox\" name=\"remember\"> <span data-i18n=\"login/index.hbs\">Recuérdame</span>\n            </label>\n        </div>\n        <button type=\"submit\" class=\"login__submit btn btn-block btn-primary\" data-i18n=\"login/index.hbs\">Iniciar sesión</button>\n        <p class=\"text-center small\"><a href=\"#login/forgot\" data-i18n=\"login/index.hbs\">Olvidaste tu contraseña</a></p>\n      </form>\n    </div>\n\n  </div>\n</div>\n\n<footer class=\""
+    + "\" placeholder=\"Su dirección de correo electrónico\">\n        </div>\n        <div class=\"form-group\">\n            <label for=\"password\" data-i18n=\"login/index.hbs\">Contraseña</label>\n            <input type=\"password\" class=\"form-control\" name=\"password\" placeholder=\"Contraseña\">\n        </div>\n        <div class=\"checkbox\">\n            <label>\n                <input type=\"checkbox\" name=\"remember\"> <span data-i18n=\"login/index.hbs\">Recuérdame</span>\n            </label>\n        </div>\n        <button type=\"submit\" class=\"login__submit btn btn-block btn-primary\" data-i18n=\"login/index.hbs\">Iniciar sesión</button>\n        <p class=\"text-center small\"><a href=\"#login/forgot\" data-i18n=\"login/index.hbs\">Olvidaste tu contraseña</a></p>\n      </form>\n    </div>\n\n  </div>\n</div>\n\n<footer class=\""
     + alias3(((helper = (helper = helpers.locale || (depth0 != null ? depth0.locale : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"locale","hash":{},"data":data}) : helper)))
     + "\">\n  Language: <a class=\"de\" href=\"../de\">de</a> | <a class=\"en\" href=\"../en\">en</a> | <a class=\"es\" href=\"../es\">es</a>\n</footer>\n";
 },"useData":true});
 
-},{"hbsfy/runtime":14}],6:[function(require,module,exports){
+},{"hbsfy/runtime":15}],6:[function(require,module,exports){
 var i18n = require("./../i18n/es/es.js")
 var tpl = require('./index.hbs')
 
@@ -107,61 +108,87 @@ document.body.innerHTML = tpl({
 })
 
 },{"./../i18n/es/es.js":3,"./index.hbs":5}],7:[function(require,module,exports){
-(function (global){
-"use strict";
-/*globals Handlebars: true */
-var base = require("./handlebars/base");
+'use strict';
+
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+
+var _import = require('./handlebars/base');
+
+var base = _interopRequireWildcard(_import);
 
 // Each of these augment the Handlebars object. No need to setup here.
 // (This is done to easily share code between commonjs and browse envs)
-var SafeString = require("./handlebars/safe-string")["default"];
-var Exception = require("./handlebars/exception")["default"];
-var Utils = require("./handlebars/utils");
-var runtime = require("./handlebars/runtime");
+
+var _SafeString = require('./handlebars/safe-string');
+
+var _SafeString2 = _interopRequireWildcard(_SafeString);
+
+var _Exception = require('./handlebars/exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var _import2 = require('./handlebars/utils');
+
+var Utils = _interopRequireWildcard(_import2);
+
+var _import3 = require('./handlebars/runtime');
+
+var runtime = _interopRequireWildcard(_import3);
+
+var _noConflict = require('./handlebars/no-conflict');
+
+var _noConflict2 = _interopRequireWildcard(_noConflict);
 
 // For compatibility and usage outside of module systems, make the Handlebars object a namespace
-var create = function() {
+function create() {
   var hb = new base.HandlebarsEnvironment();
 
   Utils.extend(hb, base);
-  hb.SafeString = SafeString;
-  hb.Exception = Exception;
+  hb.SafeString = _SafeString2['default'];
+  hb.Exception = _Exception2['default'];
   hb.Utils = Utils;
   hb.escapeExpression = Utils.escapeExpression;
 
   hb.VM = runtime;
-  hb.template = function(spec) {
+  hb.template = function (spec) {
     return runtime.template(spec, hb);
   };
 
   return hb;
-};
+}
 
-var Handlebars = create();
-Handlebars.create = create;
+var inst = create();
+inst.create = create;
 
-/*jshint -W040 */
-/* istanbul ignore next */
-var root = typeof global !== 'undefined' ? global : window,
-    $Handlebars = root.Handlebars;
-/* istanbul ignore next */
-Handlebars.noConflict = function() {
-  if (root.Handlebars === Handlebars) {
-    root.Handlebars = $Handlebars;
-  }
-};
+_noConflict2['default'](inst);
 
-Handlebars['default'] = Handlebars;
+inst['default'] = inst;
 
-exports["default"] = Handlebars;
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./handlebars/base":8,"./handlebars/exception":9,"./handlebars/runtime":10,"./handlebars/safe-string":11,"./handlebars/utils":12}],8:[function(require,module,exports){
-"use strict";
-var Utils = require("./utils");
-var Exception = require("./exception")["default"];
+exports['default'] = inst;
+module.exports = exports['default'];
+},{"./handlebars/base":8,"./handlebars/exception":9,"./handlebars/no-conflict":10,"./handlebars/runtime":11,"./handlebars/safe-string":12,"./handlebars/utils":13}],8:[function(require,module,exports){
+'use strict';
 
-var VERSION = "3.0.1";
-exports.VERSION = VERSION;var COMPILER_REVISION = 6;
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+exports.HandlebarsEnvironment = HandlebarsEnvironment;
+exports.createFrame = createFrame;
+
+var _import = require('./utils');
+
+var Utils = _interopRequireWildcard(_import);
+
+var _Exception = require('./exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var VERSION = '3.0.1';
+exports.VERSION = VERSION;
+var COMPILER_REVISION = 6;
+
 exports.COMPILER_REVISION = COMPILER_REVISION;
 var REVISION_CHANGES = {
   1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
@@ -171,6 +198,7 @@ var REVISION_CHANGES = {
   5: '== 2.0.0-alpha.x',
   6: '>= 2.0.0-beta.1'
 };
+
 exports.REVISION_CHANGES = REVISION_CHANGES;
 var isArray = Utils.isArray,
     isFunction = Utils.isFunction,
@@ -184,60 +212,62 @@ function HandlebarsEnvironment(helpers, partials) {
   registerDefaultHelpers(this);
 }
 
-exports.HandlebarsEnvironment = HandlebarsEnvironment;HandlebarsEnvironment.prototype = {
+HandlebarsEnvironment.prototype = {
   constructor: HandlebarsEnvironment,
 
   logger: logger,
   log: log,
 
-  registerHelper: function(name, fn) {
+  registerHelper: function registerHelper(name, fn) {
     if (toString.call(name) === objectType) {
-      if (fn) { throw new Exception('Arg not supported with multiple helpers'); }
+      if (fn) {
+        throw new _Exception2['default']('Arg not supported with multiple helpers');
+      }
       Utils.extend(this.helpers, name);
     } else {
       this.helpers[name] = fn;
     }
   },
-  unregisterHelper: function(name) {
+  unregisterHelper: function unregisterHelper(name) {
     delete this.helpers[name];
   },
 
-  registerPartial: function(name, partial) {
+  registerPartial: function registerPartial(name, partial) {
     if (toString.call(name) === objectType) {
-      Utils.extend(this.partials,  name);
+      Utils.extend(this.partials, name);
     } else {
       if (typeof partial === 'undefined') {
-        throw new Exception('Attempting to register a partial as undefined');
+        throw new _Exception2['default']('Attempting to register a partial as undefined');
       }
       this.partials[name] = partial;
     }
   },
-  unregisterPartial: function(name) {
+  unregisterPartial: function unregisterPartial(name) {
     delete this.partials[name];
   }
 };
 
 function registerDefaultHelpers(instance) {
-  instance.registerHelper('helperMissing', function(/* [args, ]options */) {
-    if(arguments.length === 1) {
+  instance.registerHelper('helperMissing', function () {
+    if (arguments.length === 1) {
       // A missing field in a {{foo}} constuct.
       return undefined;
     } else {
       // Someone is actually trying to call something, blow up.
-      throw new Exception("Missing helper: '" + arguments[arguments.length-1].name + "'");
+      throw new _Exception2['default']('Missing helper: "' + arguments[arguments.length - 1].name + '"');
     }
   });
 
-  instance.registerHelper('blockHelperMissing', function(context, options) {
+  instance.registerHelper('blockHelperMissing', function (context, options) {
     var inverse = options.inverse,
         fn = options.fn;
 
-    if(context === true) {
+    if (context === true) {
       return fn(this);
-    } else if(context === false || context == null) {
+    } else if (context === false || context == null) {
       return inverse(this);
     } else if (isArray(context)) {
-      if(context.length > 0) {
+      if (context.length > 0) {
         if (options.ids) {
           options.ids = [options.name];
         }
@@ -250,102 +280,111 @@ function registerDefaultHelpers(instance) {
       if (options.data && options.ids) {
         var data = createFrame(options.data);
         data.contextPath = Utils.appendContextPath(options.data.contextPath, options.name);
-        options = {data: data};
+        options = { data: data };
       }
 
       return fn(context, options);
     }
   });
 
-  instance.registerHelper('each', function(context, options) {
+  instance.registerHelper('each', function (context, options) {
     if (!options) {
-      throw new Exception('Must pass iterator to #each');
+      throw new _Exception2['default']('Must pass iterator to #each');
     }
 
-    var fn = options.fn, inverse = options.inverse;
-    var i = 0, ret = "", data;
+    var fn = options.fn,
+        inverse = options.inverse,
+        i = 0,
+        ret = '',
+        data = undefined,
+        contextPath = undefined;
 
-    var contextPath;
     if (options.data && options.ids) {
       contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
     }
 
-    if (isFunction(context)) { context = context.call(this); }
+    if (isFunction(context)) {
+      context = context.call(this);
+    }
 
     if (options.data) {
       data = createFrame(options.data);
     }
 
-    function execIteration(key, i, last) {
+    function execIteration(field, index, last) {
       if (data) {
-        data.key = key;
-        data.index = i;
-        data.first = i === 0;
-        data.last  = !!last;
+        data.key = field;
+        data.index = index;
+        data.first = index === 0;
+        data.last = !!last;
 
         if (contextPath) {
-          data.contextPath = contextPath + key;
+          data.contextPath = contextPath + field;
         }
       }
 
-      ret = ret + fn(context[key], {
+      ret = ret + fn(context[field], {
         data: data,
-        blockParams: Utils.blockParams([context[key], key], [contextPath + key, null])
+        blockParams: Utils.blockParams([context[field], field], [contextPath + field, null])
       });
     }
 
-    if(context && typeof context === 'object') {
+    if (context && typeof context === 'object') {
       if (isArray(context)) {
-        for(var j = context.length; i<j; i++) {
-          execIteration(i, i, i === context.length-1);
+        for (var j = context.length; i < j; i++) {
+          execIteration(i, i, i === context.length - 1);
         }
       } else {
-        var priorKey;
+        var priorKey = undefined;
 
-        for(var key in context) {
-          if(context.hasOwnProperty(key)) {
+        for (var key in context) {
+          if (context.hasOwnProperty(key)) {
             // We're running the iterations one step out of sync so we can detect
             // the last iteration without have to scan the object twice and create
-            // an itermediate keys array. 
+            // an itermediate keys array.
             if (priorKey) {
-              execIteration(priorKey, i-1);
+              execIteration(priorKey, i - 1);
             }
             priorKey = key;
             i++;
           }
         }
         if (priorKey) {
-          execIteration(priorKey, i-1, true);
+          execIteration(priorKey, i - 1, true);
         }
       }
     }
 
-    if(i === 0){
+    if (i === 0) {
       ret = inverse(this);
     }
 
     return ret;
   });
 
-  instance.registerHelper('if', function(conditional, options) {
-    if (isFunction(conditional)) { conditional = conditional.call(this); }
+  instance.registerHelper('if', function (conditional, options) {
+    if (isFunction(conditional)) {
+      conditional = conditional.call(this);
+    }
 
     // Default behavior is to render the positive path if the value is truthy and not empty.
     // The `includeZero` option may be set to treat the condtional as purely not empty based on the
     // behavior of isEmpty. Effectively this determines if 0 is handled by the positive path or negative.
-    if ((!options.hash.includeZero && !conditional) || Utils.isEmpty(conditional)) {
+    if (!options.hash.includeZero && !conditional || Utils.isEmpty(conditional)) {
       return options.inverse(this);
     } else {
       return options.fn(this);
     }
   });
 
-  instance.registerHelper('unless', function(conditional, options) {
-    return instance.helpers['if'].call(this, conditional, {fn: options.inverse, inverse: options.fn, hash: options.hash});
+  instance.registerHelper('unless', function (conditional, options) {
+    return instance.helpers['if'].call(this, conditional, { fn: options.inverse, inverse: options.fn, hash: options.hash });
   });
 
-  instance.registerHelper('with', function(context, options) {
-    if (isFunction(context)) { context = context.call(this); }
+  instance.registerHelper('with', function (context, options) {
+    if (isFunction(context)) {
+      context = context.call(this);
+    }
 
     var fn = options.fn;
 
@@ -353,7 +392,7 @@ function registerDefaultHelpers(instance) {
       if (options.data && options.ids) {
         var data = createFrame(options.data);
         data.contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]);
-        options = {data:data};
+        options = { data: data };
       }
 
       return fn(context, options);
@@ -362,12 +401,12 @@ function registerDefaultHelpers(instance) {
     }
   });
 
-  instance.registerHelper('log', function(message, options) {
+  instance.registerHelper('log', function (message, options) {
     var level = options.data && options.data.level != null ? parseInt(options.data.level, 10) : 1;
     instance.log(level, message);
   });
 
-  instance.registerHelper('lookup', function(obj, field) {
+  instance.registerHelper('lookup', function (obj, field) {
     return obj && obj[field];
   });
 }
@@ -383,31 +422,37 @@ var logger = {
   level: 1,
 
   // Can be overridden in the host environment
-  log: function(level, message) {
+  log: function log(level, message) {
     if (typeof console !== 'undefined' && logger.level <= level) {
       var method = logger.methodMap[level];
-      (console[method] || console.log).call(console, message);
+      (console[method] || console.log).call(console, message); // eslint-disable-line no-console
     }
   }
 };
+
 exports.logger = logger;
 var log = logger.log;
+
 exports.log = log;
-var createFrame = function(object) {
+
+function createFrame(object) {
   var frame = Utils.extend({}, object);
   frame._parent = object;
   return frame;
-};
-exports.createFrame = createFrame;
-},{"./exception":9,"./utils":12}],9:[function(require,module,exports){
-"use strict";
+}
+
+/* [args, ]options */
+},{"./exception":9,"./utils":13}],9:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
 
 var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
 
 function Exception(message, node) {
   var loc = node && node.loc,
-      line,
-      column;
+      line = undefined,
+      column = undefined;
   if (loc) {
     line = loc.start.line;
     column = loc.start.column;
@@ -422,6 +467,10 @@ function Exception(message, node) {
     this[errorProps[idx]] = tmp[errorProps[idx]];
   }
 
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, Exception);
+  }
+
   if (loc) {
     this.lineNumber = line;
     this.column = column;
@@ -430,49 +479,85 @@ function Exception(message, node) {
 
 Exception.prototype = new Error();
 
-exports["default"] = Exception;
+exports['default'] = Exception;
+module.exports = exports['default'];
 },{}],10:[function(require,module,exports){
-"use strict";
-var Utils = require("./utils");
-var Exception = require("./exception")["default"];
-var COMPILER_REVISION = require("./base").COMPILER_REVISION;
-var REVISION_CHANGES = require("./base").REVISION_CHANGES;
-var createFrame = require("./base").createFrame;
+(function (global){
+'use strict';
+
+exports.__esModule = true;
+/*global window */
+
+exports['default'] = function (Handlebars) {
+  /* istanbul ignore next */
+  var root = typeof global !== 'undefined' ? global : window,
+      $Handlebars = root.Handlebars;
+  /* istanbul ignore next */
+  Handlebars.noConflict = function () {
+    if (root.Handlebars === Handlebars) {
+      root.Handlebars = $Handlebars;
+    }
+  };
+};
+
+module.exports = exports['default'];
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],11:[function(require,module,exports){
+'use strict';
+
+var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+
+exports.__esModule = true;
+exports.checkRevision = checkRevision;
+
+// TODO: Remove this line and break up compilePartial
+
+exports.template = template;
+exports.wrapProgram = wrapProgram;
+exports.resolvePartial = resolvePartial;
+exports.invokePartial = invokePartial;
+exports.noop = noop;
+
+var _import = require('./utils');
+
+var Utils = _interopRequireWildcard(_import);
+
+var _Exception = require('./exception');
+
+var _Exception2 = _interopRequireWildcard(_Exception);
+
+var _COMPILER_REVISION$REVISION_CHANGES$createFrame = require('./base');
 
 function checkRevision(compilerInfo) {
   var compilerRevision = compilerInfo && compilerInfo[0] || 1,
-      currentRevision = COMPILER_REVISION;
+      currentRevision = _COMPILER_REVISION$REVISION_CHANGES$createFrame.COMPILER_REVISION;
 
   if (compilerRevision !== currentRevision) {
     if (compilerRevision < currentRevision) {
-      var runtimeVersions = REVISION_CHANGES[currentRevision],
-          compilerVersions = REVISION_CHANGES[compilerRevision];
-      throw new Exception("Template was precompiled with an older version of Handlebars than the current runtime. "+
-            "Please update your precompiler to a newer version ("+runtimeVersions+") or downgrade your runtime to an older version ("+compilerVersions+").");
+      var runtimeVersions = _COMPILER_REVISION$REVISION_CHANGES$createFrame.REVISION_CHANGES[currentRevision],
+          compilerVersions = _COMPILER_REVISION$REVISION_CHANGES$createFrame.REVISION_CHANGES[compilerRevision];
+      throw new _Exception2['default']('Template was precompiled with an older version of Handlebars than the current runtime. ' + 'Please update your precompiler to a newer version (' + runtimeVersions + ') or downgrade your runtime to an older version (' + compilerVersions + ').');
     } else {
       // Use the embedded version info since the runtime doesn't know about this revision yet
-      throw new Exception("Template was precompiled with a newer version of Handlebars than the current runtime. "+
-            "Please update your runtime to a newer version ("+compilerInfo[1]+").");
+      throw new _Exception2['default']('Template was precompiled with a newer version of Handlebars than the current runtime. ' + 'Please update your runtime to a newer version (' + compilerInfo[1] + ').');
     }
   }
 }
 
-exports.checkRevision = checkRevision;// TODO: Remove this line and break up compilePartial
-
 function template(templateSpec, env) {
   /* istanbul ignore next */
   if (!env) {
-    throw new Exception("No environment passed to template");
+    throw new _Exception2['default']('No environment passed to template');
   }
   if (!templateSpec || !templateSpec.main) {
-    throw new Exception('Unknown template object: ' + typeof templateSpec);
+    throw new _Exception2['default']('Unknown template object: ' + typeof templateSpec);
   }
 
   // Note: Using env.VM references rather than local var references throughout this section to allow
   // for external users to override these as psuedo-supported APIs.
   env.VM.checkRevision(templateSpec.compiler);
 
-  var invokePartialWrapper = function(partial, context, options) {
+  function invokePartialWrapper(partial, context, options) {
     if (options.hash) {
       context = Utils.extend({}, context, options.hash);
     }
@@ -498,19 +583,19 @@ function template(templateSpec, env) {
       }
       return result;
     } else {
-      throw new Exception("The partial " + options.name + " could not be compiled when running in runtime-only mode");
+      throw new _Exception2['default']('The partial ' + options.name + ' could not be compiled when running in runtime-only mode');
     }
-  };
+  }
 
   // Just add water
   var container = {
-    strict: function(obj, name) {
+    strict: function strict(obj, name) {
       if (!(name in obj)) {
-        throw new Exception('"' + name + '" not defined in ' + obj);
+        throw new _Exception2['default']('"' + name + '" not defined in ' + obj);
       }
       return obj[name];
     },
-    lookup: function(depths, name) {
+    lookup: function lookup(depths, name) {
       var len = depths.length;
       for (var i = 0; i < len; i++) {
         if (depths[i] && depths[i][name] != null) {
@@ -518,68 +603,69 @@ function template(templateSpec, env) {
         }
       }
     },
-    lambda: function(current, context) {
+    lambda: function lambda(current, context) {
       return typeof current === 'function' ? current.call(context) : current;
     },
 
     escapeExpression: Utils.escapeExpression,
     invokePartial: invokePartialWrapper,
 
-    fn: function(i) {
+    fn: function fn(i) {
       return templateSpec[i];
     },
 
     programs: [],
-    program: function(i, data, declaredBlockParams, blockParams, depths) {
+    program: function program(i, data, declaredBlockParams, blockParams, depths) {
       var programWrapper = this.programs[i],
           fn = this.fn(i);
       if (data || depths || blockParams || declaredBlockParams) {
-        programWrapper = program(this, i, fn, data, declaredBlockParams, blockParams, depths);
+        programWrapper = wrapProgram(this, i, fn, data, declaredBlockParams, blockParams, depths);
       } else if (!programWrapper) {
-        programWrapper = this.programs[i] = program(this, i, fn);
+        programWrapper = this.programs[i] = wrapProgram(this, i, fn);
       }
       return programWrapper;
     },
 
-    data: function(data, depth) {
-      while (data && depth--) {
-        data = data._parent;
+    data: function data(value, depth) {
+      while (value && depth--) {
+        value = value._parent;
       }
-      return data;
+      return value;
     },
-    merge: function(param, common) {
-      var ret = param || common;
+    merge: function merge(param, common) {
+      var obj = param || common;
 
-      if (param && common && (param !== common)) {
-        ret = Utils.extend({}, common, param);
+      if (param && common && param !== common) {
+        obj = Utils.extend({}, common, param);
       }
 
-      return ret;
+      return obj;
     },
 
     noop: env.VM.noop,
     compilerInfo: templateSpec.compiler
   };
 
-  var ret = function(context, options) {
-    options = options || {};
+  function ret(context) {
+    var options = arguments[1] === undefined ? {} : arguments[1];
+
     var data = options.data;
 
     ret._setup(options);
     if (!options.partial && templateSpec.useData) {
       data = initData(context, data);
     }
-    var depths,
+    var depths = undefined,
         blockParams = templateSpec.useBlockParams ? [] : undefined;
     if (templateSpec.useDepths) {
       depths = options.depths ? [context].concat(options.depths) : [context];
     }
 
     return templateSpec.main.call(container, context, container.helpers, container.partials, data, blockParams, depths);
-  };
+  }
   ret.isTop = true;
 
-  ret._setup = function(options) {
+  ret._setup = function (options) {
     if (!options.partial) {
       container.helpers = container.merge(options.helpers, env.helpers);
 
@@ -592,37 +678,32 @@ function template(templateSpec, env) {
     }
   };
 
-  ret._child = function(i, data, blockParams, depths) {
+  ret._child = function (i, data, blockParams, depths) {
     if (templateSpec.useBlockParams && !blockParams) {
-      throw new Exception('must pass block params');
+      throw new _Exception2['default']('must pass block params');
     }
     if (templateSpec.useDepths && !depths) {
-      throw new Exception('must pass parent depths');
+      throw new _Exception2['default']('must pass parent depths');
     }
 
-    return program(container, i, templateSpec[i], data, 0, blockParams, depths);
+    return wrapProgram(container, i, templateSpec[i], data, 0, blockParams, depths);
   };
   return ret;
 }
 
-exports.template = template;function program(container, i, fn, data, declaredBlockParams, blockParams, depths) {
-  var prog = function(context, options) {
-    options = options || {};
+function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, depths) {
+  function prog(context) {
+    var options = arguments[1] === undefined ? {} : arguments[1];
 
-    return fn.call(container,
-        context,
-        container.helpers, container.partials,
-        options.data || data,
-        blockParams && [options.blockParams].concat(blockParams),
-        depths && [context].concat(depths));
-  };
+    return fn.call(container, context, container.helpers, container.partials, options.data || data, blockParams && [options.blockParams].concat(blockParams), depths && [context].concat(depths));
+  }
   prog.program = i;
   prog.depth = depths ? depths.length : 0;
   prog.blockParams = declaredBlockParams || 0;
   return prog;
 }
 
-exports.program = program;function resolvePartial(partial, context, options) {
+function resolvePartial(partial, context, options) {
   if (!partial) {
     partial = options.partials[options.name];
   } else if (!partial.call && !options.name) {
@@ -633,51 +714,65 @@ exports.program = program;function resolvePartial(partial, context, options) {
   return partial;
 }
 
-exports.resolvePartial = resolvePartial;function invokePartial(partial, context, options) {
+function invokePartial(partial, context, options) {
   options.partial = true;
 
-  if(partial === undefined) {
-    throw new Exception("The partial " + options.name + " could not be found");
-  } else if(partial instanceof Function) {
+  if (partial === undefined) {
+    throw new _Exception2['default']('The partial ' + options.name + ' could not be found');
+  } else if (partial instanceof Function) {
     return partial(context, options);
   }
 }
 
-exports.invokePartial = invokePartial;function noop() { return ""; }
+function noop() {
+  return '';
+}
 
-exports.noop = noop;function initData(context, data) {
+function initData(context, data) {
   if (!data || !('root' in data)) {
-    data = data ? createFrame(data) : {};
+    data = data ? _COMPILER_REVISION$REVISION_CHANGES$createFrame.createFrame(data) : {};
     data.root = context;
   }
   return data;
 }
-},{"./base":8,"./exception":9,"./utils":12}],11:[function(require,module,exports){
-"use strict";
+},{"./base":8,"./exception":9,"./utils":13}],12:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
 // Build out our basic SafeString type
 function SafeString(string) {
   this.string = string;
 }
 
-SafeString.prototype.toString = SafeString.prototype.toHTML = function() {
-  return "" + this.string;
+SafeString.prototype.toString = SafeString.prototype.toHTML = function () {
+  return '' + this.string;
 };
 
-exports["default"] = SafeString;
-},{}],12:[function(require,module,exports){
-"use strict";
-/*jshint -W004 */
+exports['default'] = SafeString;
+module.exports = exports['default'];
+},{}],13:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
+exports.extend = extend;
+
+// Older IE versions do not directly support indexOf so we must implement our own, sadly.
+exports.indexOf = indexOf;
+exports.escapeExpression = escapeExpression;
+exports.isEmpty = isEmpty;
+exports.blockParams = blockParams;
+exports.appendContextPath = appendContextPath;
 var escape = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&#x27;",
-  "`": "&#x60;"
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  '\'': '&#x27;',
+  '`': '&#x60;'
 };
 
-var badChars = /[&<>"'`]/g;
-var possible = /[&<>"'`]/;
+var badChars = /[&<>"'`]/g,
+    possible = /[&<>"'`]/;
 
 function escapeChar(chr) {
   return escape[chr];
@@ -695,28 +790,31 @@ function extend(obj /* , ...source */) {
   return obj;
 }
 
-exports.extend = extend;var toString = Object.prototype.toString;
+var toString = Object.prototype.toString;
+
 exports.toString = toString;
 // Sourced from lodash
 // https://github.com/bestiejs/lodash/blob/master/LICENSE.txt
-var isFunction = function(value) {
+/*eslint-disable func-style, no-var */
+var isFunction = function isFunction(value) {
   return typeof value === 'function';
 };
 // fallback for older versions of Chrome and Safari
 /* istanbul ignore next */
 if (isFunction(/x/)) {
-  isFunction = function(value) {
+  exports.isFunction = isFunction = function (value) {
     return typeof value === 'function' && toString.call(value) === '[object Function]';
   };
 }
 var isFunction;
 exports.isFunction = isFunction;
+/*eslint-enable func-style, no-var */
+
 /* istanbul ignore next */
-var isArray = Array.isArray || function(value) {
-  return (value && typeof value === 'object') ? toString.call(value) === '[object Array]' : false;
-};
-exports.isArray = isArray;
-// Older IE versions do not directly support indexOf so we must implement our own, sadly.
+var isArray = Array.isArray || function (value) {
+  return value && typeof value === 'object' ? toString.call(value) === '[object Array]' : false;
+};exports.isArray = isArray;
+
 function indexOf(array, value) {
   for (var i = 0, len = array.length; i < len; i++) {
     if (array[i] === value) {
@@ -726,7 +824,6 @@ function indexOf(array, value) {
   return -1;
 }
 
-exports.indexOf = indexOf;
 function escapeExpression(string) {
   if (typeof string !== 'string') {
     // don't escape SafeStrings, since they're already safe
@@ -744,11 +841,13 @@ function escapeExpression(string) {
     string = '' + string;
   }
 
-  if (!possible.test(string)) { return string; }
+  if (!possible.test(string)) {
+    return string;
+  }
   return string.replace(badChars, escapeChar);
 }
 
-exports.escapeExpression = escapeExpression;function isEmpty(value) {
+function isEmpty(value) {
   if (!value && value !== 0) {
     return true;
   } else if (isArray(value) && value.length === 0) {
@@ -758,25 +857,23 @@ exports.escapeExpression = escapeExpression;function isEmpty(value) {
   }
 }
 
-exports.isEmpty = isEmpty;function blockParams(params, ids) {
+function blockParams(params, ids) {
   params.path = ids;
   return params;
 }
 
-exports.blockParams = blockParams;function appendContextPath(contextPath, id) {
+function appendContextPath(contextPath, id) {
   return (contextPath ? contextPath + '.' : '') + id;
 }
-
-exports.appendContextPath = appendContextPath;
-},{}],13:[function(require,module,exports){
+},{}],14:[function(require,module,exports){
 // Create a simple path alias to allow browserify to resolve
 // the runtime on a supported path.
 module.exports = require('./dist/cjs/handlebars.runtime')['default'];
 
-},{"./dist/cjs/handlebars.runtime":7}],14:[function(require,module,exports){
+},{"./dist/cjs/handlebars.runtime":7}],15:[function(require,module,exports){
 module.exports = require("handlebars/runtime")["default"];
 
-},{"handlebars/runtime":13}],15:[function(require,module,exports){
+},{"handlebars/runtime":14}],16:[function(require,module,exports){
 /**
  * @preserve jed.js https://github.com/SlexAxton/Jed
  */
@@ -1800,7 +1897,7 @@ return parser;
 
 })(this);
 
-},{}],16:[function(require,module,exports){
+},{}],17:[function(require,module,exports){
 //! moment.js locale configuration
 //! locale : spanish (es)
 //! author : Julio Napurí : https://github.com/julionc
@@ -1812,11 +1909,11 @@ return parser;
 }(this, function (moment) { 'use strict';
 
 
-    var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
-        monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');
+    var monthsShortDot = 'Ene._Feb._Mar._Abr._May._Jun._Jul._Ago._Sep._Oct._Nov._Dic.'.split('_'),
+        monthsShort = 'Ene_Feb_Mar_Abr_May_Jun_Jul_Ago_Sep_Oct_Nov_Dic'.split('_');
 
     var es = moment.defineLocale('es', {
-        months : 'enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre'.split('_'),
+        months : 'Enero_Febrero_Marzo_Abril_Mayo_Junio_Julio_Agosto_Septiembre_Octubre_Noviembre_Diciembre'.split('_'),
         monthsShort : function (m, format) {
             if (/-MMM-/.test(format)) {
                 return monthsShort[m.month()];
@@ -1824,8 +1921,8 @@ return parser;
                 return monthsShortDot[m.month()];
             }
         },
-        weekdays : 'domingo_lunes_martes_miércoles_jueves_viernes_sábado'.split('_'),
-        weekdaysShort : 'dom._lun._mar._mié._jue._vie._sáb.'.split('_'),
+        weekdays : 'Domingo_Lunes_Martes_Miércoles_Jueves_Viernes_Sábado'.split('_'),
+        weekdaysShort : 'Dom._Lun._Mar._Mié._Jue._Vie._Sáb.'.split('_'),
         weekdaysMin : 'Do_Lu_Ma_Mi_Ju_Vi_Sá'.split('_'),
         longDateFormat : {
             LT : 'H:mm',
@@ -1879,9 +1976,9 @@ return parser;
     return es;
 
 }));
-},{"../moment":17}],17:[function(require,module,exports){
+},{"../moment":18}],18:[function(require,module,exports){
 //! moment.js
-//! version : 2.10.2
+//! version : 2.10.3
 //! authors : Tim Wood, Iskren Chernev, Moment.js contributors
 //! license : MIT
 //! momentjs.com
@@ -1904,28 +2001,12 @@ return parser;
         hookCallback = callback;
     }
 
-    function defaultParsingFlags() {
-        // We need to deep clone this object.
-        return {
-            empty           : false,
-            unusedTokens    : [],
-            unusedInput     : [],
-            overflow        : -2,
-            charsLeftOver   : 0,
-            nullInput       : false,
-            invalidMonth    : null,
-            invalidFormat   : false,
-            userInvalidated : false,
-            iso             : false
-        };
-    }
-
     function isArray(input) {
         return Object.prototype.toString.call(input) === '[object Array]';
     }
 
     function isDate(input) {
-        return Object.prototype.toString.call(input) === '[object Date]' || input instanceof Date;
+        return input instanceof Date || Object.prototype.toString.call(input) === '[object Date]';
     }
 
     function map(arr, fn) {
@@ -1962,21 +2043,45 @@ return parser;
         return createLocalOrUTC(input, format, locale, strict, true).utc();
     }
 
+    function defaultParsingFlags() {
+        // We need to deep clone this object.
+        return {
+            empty           : false,
+            unusedTokens    : [],
+            unusedInput     : [],
+            overflow        : -2,
+            charsLeftOver   : 0,
+            nullInput       : false,
+            invalidMonth    : null,
+            invalidFormat   : false,
+            userInvalidated : false,
+            iso             : false
+        };
+    }
+
+    function getParsingFlags(m) {
+        if (m._pf == null) {
+            m._pf = defaultParsingFlags();
+        }
+        return m._pf;
+    }
+
     function valid__isValid(m) {
         if (m._isValid == null) {
+            var flags = getParsingFlags(m);
             m._isValid = !isNaN(m._d.getTime()) &&
-                m._pf.overflow < 0 &&
-                !m._pf.empty &&
-                !m._pf.invalidMonth &&
-                !m._pf.nullInput &&
-                !m._pf.invalidFormat &&
-                !m._pf.userInvalidated;
+                flags.overflow < 0 &&
+                !flags.empty &&
+                !flags.invalidMonth &&
+                !flags.nullInput &&
+                !flags.invalidFormat &&
+                !flags.userInvalidated;
 
             if (m._strict) {
                 m._isValid = m._isValid &&
-                    m._pf.charsLeftOver === 0 &&
-                    m._pf.unusedTokens.length === 0 &&
-                    m._pf.bigHour === undefined;
+                    flags.charsLeftOver === 0 &&
+                    flags.unusedTokens.length === 0 &&
+                    flags.bigHour === undefined;
             }
         }
         return m._isValid;
@@ -1985,10 +2090,10 @@ return parser;
     function valid__createInvalid (flags) {
         var m = create_utc__createUTC(NaN);
         if (flags != null) {
-            extend(m._pf, flags);
+            extend(getParsingFlags(m), flags);
         }
         else {
-            m._pf.userInvalidated = true;
+            getParsingFlags(m).userInvalidated = true;
         }
 
         return m;
@@ -2024,7 +2129,7 @@ return parser;
             to._offset = from._offset;
         }
         if (typeof from._pf !== 'undefined') {
-            to._pf = from._pf;
+            to._pf = getParsingFlags(from);
         }
         if (typeof from._locale !== 'undefined') {
             to._locale = from._locale;
@@ -2059,7 +2164,7 @@ return parser;
     }
 
     function isMoment (obj) {
-        return obj instanceof Moment || (obj != null && hasOwnProp(obj, '_isAMomentObject'));
+        return obj instanceof Moment || (obj != null && obj._isAMomentObject != null);
     }
 
     function toInt(argumentForCoercion) {
@@ -2497,7 +2602,7 @@ return parser;
         if (month != null) {
             array[MONTH] = month;
         } else {
-            config._pf.invalidMonth = input;
+            getParsingFlags(config).invalidMonth = input;
         }
     });
 
@@ -2581,7 +2686,7 @@ return parser;
         var overflow;
         var a = m._a;
 
-        if (a && m._pf.overflow === -2) {
+        if (a && getParsingFlags(m).overflow === -2) {
             overflow =
                 a[MONTH]       < 0 || a[MONTH]       > 11  ? MONTH :
                 a[DATE]        < 1 || a[DATE]        > daysInMonth(a[YEAR], a[MONTH]) ? DATE :
@@ -2591,11 +2696,11 @@ return parser;
                 a[MILLISECOND] < 0 || a[MILLISECOND] > 999 ? MILLISECOND :
                 -1;
 
-            if (m._pf._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
+            if (getParsingFlags(m)._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
                 overflow = DATE;
             }
 
-            m._pf.overflow = overflow;
+            getParsingFlags(m).overflow = overflow;
         }
 
         return m;
@@ -2608,10 +2713,12 @@ return parser;
     }
 
     function deprecate(msg, fn) {
-        var firstTime = true;
+        var firstTime = true,
+            msgWithStack = msg + '\n' + (new Error()).stack;
+
         return extend(function () {
             if (firstTime) {
-                warn(msg);
+                warn(msgWithStack);
                 firstTime = false;
             }
             return fn.apply(this, arguments);
@@ -2656,7 +2763,7 @@ return parser;
             match = from_string__isoRegex.exec(string);
 
         if (match) {
-            config._pf.iso = true;
+            getParsingFlags(config).iso = true;
             for (i = 0, l = isoDates.length; i < l; i++) {
                 if (isoDates[i][1].exec(string)) {
                     // match[5] should be 'T' or undefined
@@ -2936,7 +3043,7 @@ return parser;
             yearToUse = defaults(config._a[YEAR], currentDate[YEAR]);
 
             if (config._dayOfYear > daysInYear(yearToUse)) {
-                config._pf._overflowDayOfYear = true;
+                getParsingFlags(config)._overflowDayOfYear = true;
             }
 
             date = createUTCDate(yearToUse, 0, config._dayOfYear);
@@ -3032,7 +3139,7 @@ return parser;
         }
 
         config._a = [];
-        config._pf.empty = true;
+        getParsingFlags(config).empty = true;
 
         // This array is used to make a Date, either with `new Date` or `Date.UTC`
         var string = '' + config._i,
@@ -3048,7 +3155,7 @@ return parser;
             if (parsedInput) {
                 skipped = string.substr(0, string.indexOf(parsedInput));
                 if (skipped.length > 0) {
-                    config._pf.unusedInput.push(skipped);
+                    getParsingFlags(config).unusedInput.push(skipped);
                 }
                 string = string.slice(string.indexOf(parsedInput) + parsedInput.length);
                 totalParsedInputLength += parsedInput.length;
@@ -3056,27 +3163,29 @@ return parser;
             // don't parse if it's not a known token
             if (formatTokenFunctions[token]) {
                 if (parsedInput) {
-                    config._pf.empty = false;
+                    getParsingFlags(config).empty = false;
                 }
                 else {
-                    config._pf.unusedTokens.push(token);
+                    getParsingFlags(config).unusedTokens.push(token);
                 }
                 addTimeToArrayFromToken(token, parsedInput, config);
             }
             else if (config._strict && !parsedInput) {
-                config._pf.unusedTokens.push(token);
+                getParsingFlags(config).unusedTokens.push(token);
             }
         }
 
         // add remaining unparsed input length to the string
-        config._pf.charsLeftOver = stringLength - totalParsedInputLength;
+        getParsingFlags(config).charsLeftOver = stringLength - totalParsedInputLength;
         if (string.length > 0) {
-            config._pf.unusedInput.push(string);
+            getParsingFlags(config).unusedInput.push(string);
         }
 
         // clear _12h flag if hour is <= 12
-        if (config._pf.bigHour === true && config._a[HOUR] <= 12) {
-            config._pf.bigHour = undefined;
+        if (getParsingFlags(config).bigHour === true &&
+                config._a[HOUR] <= 12 &&
+                config._a[HOUR] > 0) {
+            getParsingFlags(config).bigHour = undefined;
         }
         // handle meridiem
         config._a[HOUR] = meridiemFixWrap(config._locale, config._a[HOUR], config._meridiem);
@@ -3120,7 +3229,7 @@ return parser;
             currentScore;
 
         if (config._f.length === 0) {
-            config._pf.invalidFormat = true;
+            getParsingFlags(config).invalidFormat = true;
             config._d = new Date(NaN);
             return;
         }
@@ -3131,7 +3240,6 @@ return parser;
             if (config._useUTC != null) {
                 tempConfig._useUTC = config._useUTC;
             }
-            tempConfig._pf = defaultParsingFlags();
             tempConfig._f = config._f[i];
             configFromStringAndFormat(tempConfig);
 
@@ -3140,12 +3248,12 @@ return parser;
             }
 
             // if there is any input that was not parsed add a penalty for that format
-            currentScore += tempConfig._pf.charsLeftOver;
+            currentScore += getParsingFlags(tempConfig).charsLeftOver;
 
             //or tokens
-            currentScore += tempConfig._pf.unusedTokens.length * 10;
+            currentScore += getParsingFlags(tempConfig).unusedTokens.length * 10;
 
-            tempConfig._pf.score = currentScore;
+            getParsingFlags(tempConfig).score = currentScore;
 
             if (scoreToBeat == null || currentScore < scoreToBeat) {
                 scoreToBeat = currentScore;
@@ -3188,6 +3296,8 @@ return parser;
             configFromStringAndArray(config);
         } else if (format) {
             configFromStringAndFormat(config);
+        } else if (isDate(input)) {
+            config._d = input;
         } else {
             configFromInput(config);
         }
@@ -3240,7 +3350,6 @@ return parser;
         c._i = input;
         c._f = format;
         c._strict = strict;
-        c._pf = defaultParsingFlags();
 
         return createFromConfig(c);
     }
@@ -3814,11 +3923,25 @@ return parser;
     }
 
     function from (time, withoutSuffix) {
+        if (!this.isValid()) {
+            return this.localeData().invalidDate();
+        }
         return create__createDuration({to: this, from: time}).locale(this.locale()).humanize(!withoutSuffix);
     }
 
     function fromNow (withoutSuffix) {
         return this.from(local__createLocal(), withoutSuffix);
+    }
+
+    function to (time, withoutSuffix) {
+        if (!this.isValid()) {
+            return this.localeData().invalidDate();
+        }
+        return create__createDuration({from: this, to: time}).locale(this.locale()).humanize(!withoutSuffix);
+    }
+
+    function toNow (withoutSuffix) {
+        return this.to(local__createLocal(), withoutSuffix);
     }
 
     function locale (key) {
@@ -3923,11 +4046,11 @@ return parser;
     }
 
     function parsingFlags () {
-        return extend({}, this._pf);
+        return extend({}, getParsingFlags(this));
     }
 
     function invalidAt () {
-        return this._pf.overflow;
+        return getParsingFlags(this).overflow;
     }
 
     addFormatToken(0, ['gg', 2], 0, function () {
@@ -4078,7 +4201,7 @@ return parser;
         if (weekday != null) {
             week.d = weekday;
         } else {
-            config._pf.invalidWeekday = input;
+            getParsingFlags(config).invalidWeekday = input;
         }
     });
 
@@ -4203,7 +4326,7 @@ return parser;
     });
     addParseToken(['h', 'hh'], function (input, array, config) {
         array[HOUR] = toInt(input);
-        config._pf.bigHour = true;
+        getParsingFlags(config).bigHour = true;
     });
 
     // LOCALES
@@ -4320,6 +4443,8 @@ return parser;
     momentPrototype__proto.format       = format;
     momentPrototype__proto.from         = from;
     momentPrototype__proto.fromNow      = fromNow;
+    momentPrototype__proto.to           = to;
+    momentPrototype__proto.toNow        = toNow;
     momentPrototype__proto.get          = getSet;
     momentPrototype__proto.invalidAt    = invalidAt;
     momentPrototype__proto.isAfter      = isAfter;
@@ -4508,7 +4633,7 @@ return parser;
         }
         // Lenient ordinal parsing accepts just a number in addition to
         // number + (possibly) stuff coming from _ordinalParseLenient.
-        this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + /\d{1,2}/.source);
+        this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + (/\d{1,2}/).source);
     }
 
     var prototype__proto = Locale.prototype;
@@ -4725,13 +4850,13 @@ return parser;
             // handle milliseconds separately because of floating point math errors (issue #1867)
             days = this._days + Math.round(yearsToDays(this._months / 12));
             switch (units) {
-                case 'week'   : return days / 7            + milliseconds / 6048e5;
-                case 'day'    : return days                + milliseconds / 864e5;
-                case 'hour'   : return days * 24           + milliseconds / 36e5;
-                case 'minute' : return days * 24 * 60      + milliseconds / 6e4;
-                case 'second' : return days * 24 * 60 * 60 + milliseconds / 1000;
+                case 'week'   : return days / 7     + milliseconds / 6048e5;
+                case 'day'    : return days         + milliseconds / 864e5;
+                case 'hour'   : return days * 24    + milliseconds / 36e5;
+                case 'minute' : return days * 1440  + milliseconds / 6e4;
+                case 'second' : return days * 86400 + milliseconds / 1000;
                 // Math.floor prevents floating point math errors here
-                case 'millisecond': return Math.floor(days * 24 * 60 * 60 * 1000) + milliseconds;
+                case 'millisecond': return Math.floor(days * 864e5) + milliseconds;
                 default: throw new Error('Unknown unit ' + units);
             }
         }
@@ -4932,7 +5057,7 @@ return parser;
     // Side effect imports
 
 
-    utils_hooks__hooks.version = '2.10.2';
+    utils_hooks__hooks.version = '2.10.3';
 
     setHookCallback(local__createLocal);
 

--- a/i18n/de/dict.json
+++ b/i18n/de/dict.json
@@ -14,6 +14,7 @@
     "There is 1 new alert": ["Es gibt ein neues alarm", "Es gibt 3 neue Alarm"],
     "There is 1 new warning": ["Es gibt ein neues warnung", "Es gibt 3 neue warnungen"],
     "There will be 1h of scheduled maintenance on %s": ["Es wird am %s 1 Uhr von wartungsarbeiten werden"],
-    "Please enter your email and password to log in": ["Bitte geben Sie Ihre E-Mail und Passwort für die Anmeldung in"]
+    "Please enter your email and password to log in": ["Bitte geben Sie Ihre E-Mail und Passwort für die Anmeldung in"],
+    "Your email address": ["Ihre E-Mail-Adresse"]
   }
 }

--- a/i18n/es/dict.json
+++ b/i18n/es/dict.json
@@ -17,6 +17,7 @@
     "There is 1 new alert": ["Hay 1 nueva alerta", "Hay %s nuevas alertas"],
     "There is %d new warning": ["Hay 1 nuevo aviso", "Hay %d nuevos avisos"],
     "There will be 1h of scheduled maintenance on %s": ["Habrá 1h de mantenimiento programado el %s"],
-    "Please enter your email and password to log in": ["Por favor, introduzca su correo electrónico y contraseña para entrar"]
+    "Please enter your email and password to log in": ["Por favor, introduzca su correo electrónico y contraseña para entrar"],
+    "Your email address": ["Su dirección de correo electrónico"]
   }
 }

--- a/login/index.hbs
+++ b/login/index.hbs
@@ -33,11 +33,11 @@
         </p>
         <div class="form-group">
             <label for="username" data-i18n>Email</label>
-            <input type="text" class="form-control" name="username" autocorrect="off" autocapitalize="off" value="{{{prefill.username}}}">
+            <input type="text" class="form-control" name="username" autocorrect="off" autocapitalize="off" value="{{{prefill.username}}}" placeholder="Your email address" data-i18n-attr="placeholder">
         </div>
         <div class="form-group">
             <label for="password" data-i18n>Password</label>
-            <input type="password" class="form-control" name="password">
+            <input type="password" class="form-control" name="password" placeholder="Password" data-i18n-attr="placeholder">
         </div>
         <div class="checkbox">
             <label>


### PR DESCRIPTION
Turns out there's no CSS selector for selecting partial attributes, so we can't do the slightly nicer "data-i18n-placeholder" to translate the placeholder attribute (at least not using trumpet).

This PR allows you to add `data-i18n-attr="placeholder"` to have i18ify translate the placeholder attribute.

Should you really need to, you can translate multiple attributes by space separating their names e.g. `data-i18n-attr="placeholder title"`.
